### PR TITLE
Provide test for request.js

### DIFF
--- a/packages/cozy-konnector-libs/libs/request.spec.js
+++ b/packages/cozy-konnector-libs/libs/request.spec.js
@@ -1,0 +1,23 @@
+const requestFactory = require('./request')
+
+describe('requestFactory', function () {
+  const defaultops = { json: false, cheerio: true }
+  describe('when loading a `latin1` encoded page', () => {
+    const latin1url = 'https://www.credit-cooperatif.coop/portail/particuliers/login.do'
+    it('should not be able to read it correctly if not told how', () => {
+      const rq = requestFactory(defaultops)
+      return rq(latin1url)
+      .then($ => {
+        expect($('.navSecurite').text()).not.toEqual('sécurité')
+      })
+    })
+
+    it('should be able to read it correctly if told how', () => {
+      const rq = requestFactory({encoding: 'latin1', ...defaultops})
+      return rq(latin1url)
+      .then($ => {
+        expect($('.navSecurite').text()).toEqual('sécurité')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Test encoding option for `requestFactory`.

I don't know if you will find it useful.
I have written them to get used to writing tests in your libs.

I am still unable to make `replay` work in your environment.
These tests emit requests, which make them network dependent.
If no one can patch them with `replay`, the network dependency can be annoying.