### PR TITLE
fix: yarn dev now works without defining the file source

### DIFF
--- a/packages/cozy-jobs-cli/src/dev.js
+++ b/packages/cozy-jobs-cli/src/dev.js
@@ -19,12 +19,13 @@ program
   .usage('[options] <file>')
   .arguments('<file>')
   .action(_file => {
-    _file = _file || process.env.npm_package_main || 'index.js'
-    file = abspath(_file)
+    file = _file
   })
   .option('-t, --token [value]', 'Token file location (will be created if does not exist)', abspath)
   .option('-m, --manifest [value]', 'Manifest file for permissions (manifest.webapp or manifest.konnector)', abspath)
   .parse(process.argv)
+
+file = abspath(file || process.env.npm_package_main || './src/index.js')
 
 // Check for a .konnector file next to the launched file
 manifest = program.manifest

--- a/packages/cozy-jobs-cli/src/standalone.js
+++ b/packages/cozy-jobs-cli/src/standalone.js
@@ -17,7 +17,7 @@ process.env.COZY_FIELDS = JSON.stringify({
 const config = require('./init-konnector-config')()
 process.env.COZY_URL = config.COZY_URL
 
-const filename = program.args[0] || process.env.npm_package_main || 'index.js'
+const filename = program.args[0] || process.env.npm_package_main || './src/index.js'
 
 initReplay()
 


### PR DESCRIPTION
`yarn dev` did not work when you did not define the main connector file explicitely.

Also defined default main connector file as `./src/index.js` to be compatible with template defaults.