### PR TITLE
fix: add fetchJSON in cozy-client-js-stub

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -115,6 +115,9 @@ module.exports = {
         fs.mkdirSync(finalPath)
         resolve()
       })
+    },
+    fetchJSON () {
+      Promise.resolve({})
     }
   }
 }


### PR DESCRIPTION
This is needed especially when oauth connectors try to refresh their tokens