### PR TITLE
✨ feat: if message is an object, its properties are assigned to the log

### DIFF
--- a/packages/cozy-logger/src/log-formats.js
+++ b/packages/cozy-logger/src/log-formats.js
@@ -17,11 +17,21 @@ const type2color = {
 }
 
 function prodFormat (type, message, label, namespace) {
+  const log = { time: new Date(), type, label, namespace }
+
+  if (typeof message == 'object') {
+    Object.assign(log, message)
+  } else {
+    log.message = message
+  }
+
   // properly display error messages
-  if (message.stack) message = message.stack
+  if (log.message.stack) {
+    log.message = log.message.stack
+  }
 
   // cut the string to avoid a fail in the stack
-  return JSON.stringify({ time: new Date(), type, message, label, namespace }).substr(0, LOG_LENGTH_LIMIT)
+  return JSON.stringify(log).substr(0, LOG_LENGTH_LIMIT)
 }
 
 function devFormat (type, message, label, namespace) {


### PR DESCRIPTION
To deactivate the automatic retry from the stack, we need to pass the no_retry
option in the message. With this PR, it possible to do

```
logger.critical({ message: 'LOGIN_FAILED', no_retry: true })
```