### PR TITLE
🐝 fix: use target node 8 to remove the need for regeneratorRuntime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,10 @@
 {
   "presets": [
-    "env"
+    ["env", {
+      "targets": {
+        "node": "8"
+      }
+    }]
   ],
   "plugins": [
     "transform-object-rest-spread"

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -47,7 +47,8 @@
     "uuid": "^3.1.0"
   },
   "scripts": {
-    "prepublishOnly": "babel src --out-dir dist",
+    "transpile": "babel src --out-dir dist",
+    "prepublishOnly": "yarn run transpile",
     "lint": "standard --fix commands/* helpers/* libs/* index.js",
     "test": "cross-env LOG_LEVEL=info jest",
     "doc": "jsdoc2md --template jsdoc2md/README.hbs libs/*.js helpers/*.js > docs/api.md"


### PR DESCRIPTION
Since the target was not specified, await/async was transpiled to use regeneratorRuntime and it needed to be installed by the host. Node 8 supports async/await so there is no need for transpilation.