### PR TITLE
fix: cozy-logger : check JSON.stringify errors in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "doc": "cd packages/cozy-konnector-libs && jsdoc2md --template jsdoc2md/README.hbs libs/*.js helpers/*.js > docs/api.md",
     "lint": "eslint .",
     "test": "cross-env LOG_LEVEL=info jest"
+  },
+  "dependencies": {
+    "json-stringify-safe": "5.0.1"
   }
 }

--- a/packages/cozy-logger/src/log-formats.js
+++ b/packages/cozy-logger/src/log-formats.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk')
 const util = require('util')
+const stringify = require('json-stringify-safe')
 util.inspect.defaultOptions.maxArrayLength = null
 util.inspect.defaultOptions.depth = null
 util.inspect.defaultOptions.colors = true
@@ -33,7 +34,7 @@ function prodFormat (type, message, label, namespace) {
   // cut the string to avoid a fail in the stack
   let result = log
   try {
-    result = JSON.stringify(log).substr(0, LOG_LENGTH_LIMIT)
+    result = stringify(log).substr(0, LOG_LENGTH_LIMIT)
   } catch (err) {
     console.log(err.message, 'cozy-logger: Failed to convert message to JSON')
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,7 +3140,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 


### PR DESCRIPTION
Example, when we try to log an object with circular reference, we cannot JSON.stringify it (ex : an entry with a `filestream` attribute), we get an exception.

We should not get an exception for a logging feature.