### PR TITLE
fix: put fetchJSON in the right place

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -14,6 +14,9 @@ if (fs.existsSync(FIXTURE_PATH)) {
 }
 
 module.exports = {
+  fetchJSON () {
+    Promise.resolve({})
+  },
   data: {
     create (doctype, item) {
       log('info', item, `creating ${doctype}`)
@@ -115,9 +118,6 @@ module.exports = {
         fs.mkdirSync(finalPath)
         resolve()
       })
-    },
-    fetchJSON () {
-      Promise.resolve({})
     }
   }
 }


### PR DESCRIPTION
The fetchJSON method was in cozyClient.files

This made running a connector using saveBills fail in standalone mode