### PR TITLE
fix: recognize webpack's 'none' mode as 'production' mode

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -70,4 +70,6 @@ const getCozyClient = function (environment = 'production') {
   return cozyClient
 }
 
-module.exports = getCozyClient(process.env.NODE_ENV)
+// webpack 4 now changes the NODE_ENV environment variable when you change its 'mode' option
+// since we do not want to minimize the built file, we recognize the 'none' mode as production mode
+module.exports = getCozyClient(process.env.NODE_ENV === 'none' ? 'production' : process.env.NODE_ENV)


### PR DESCRIPTION
The webpack built connectors does not work when the webpack `mode` option is set to development` or `none`.

This is due to the fact that webpack, since it's 4th version, changes the `NODE_ENV` environment variable. And the `cozy-konnector-libs.cozyClient` also uses this environment variable to know if the `yarn standalone` or `yarn dev` commands are run and do the proper initialization.

The production mode of webpack is quite unstable for the node mode ("assignment to constant variable", the scrape function does not work in this mode and it makes it difficult to debug connectors)

I propose to use use the `none` mode as `production` mode in cozyClient. And will update the connector template to use the `none` mode.

PS And it also makes the webpack build a lot faster.