### PR TITLE
fix: formatting of error is done in cozy-logger

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -181,8 +181,8 @@ class BaseKonnector {
    * @param  {string} message - The error code to be saved as connector result see [docs/ERROR_CODES.md]
    */
   terminate (err) {
-    log('error', err.message || err)
-    log('critical', err.message || err)
+    log('error', err)
+    log('critical', err)
     captureExceptionAndDie(err)
   }
 }


### PR DESCRIPTION
It is important for the full error to reach the logger for the no_retry usecase