### PR TITLE
Adding a new DISK_QUOTA_EXCEEDED error code when the cozy is full

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/errors.js
+++ b/packages/cozy-konnector-libs/src/helpers/errors.js
@@ -36,11 +36,18 @@ const FILE_DOWNLOAD_FAILED = 'FILE_DOWNLOAD_FAILED'
  */
 const SAVE_FILE_FAILED = 'SAVE_FILE_FAILED'
 
+/**
+ * Could not save a file to the cozy because of disk quota exceeded
+ * @type {String}
+ */
+const DISK_QUOTA_EXCEEDED = 'DISK_QUOTA_EXCEEDED'
+
 module.exports = {
   LOGIN_FAILED,
   NOT_EXISTING_DIRECTORY,
   VENDOR_DOWN,
   USER_ACTION_NEEDED,
   FILE_DOWNLOAD_FAILED,
-  SAVE_FILE_FAILED
+  SAVE_FILE_FAILED,
+  DISK_QUOTA_EXCEEDED
 }

--- a/packages/cozy-konnector-libs/src/helpers/errors.js
+++ b/packages/cozy-konnector-libs/src/helpers/errors.js
@@ -1,17 +1,5 @@
 'use strict'
 
-const log = require('cozy-logger')
-
-const MSG = {
-  TWOFACTOR: '2FA token requested'
-}
-
-function requireTwoFactor (extras = {}) {
-  const extrasStr = Buffer.from(JSON.stringify(extras), 'binary').toString('base64')
-  log('error', `${MSG.TWOFACTOR}||${extrasStr}`)
-  return extrasStr
-}
-
 /**
  * The konnector could not login
  * @type {String}
@@ -49,12 +37,10 @@ const FILE_DOWNLOAD_FAILED = 'FILE_DOWNLOAD_FAILED'
 const SAVE_FILE_FAILED = 'SAVE_FILE_FAILED'
 
 module.exports = {
-  MSG: MSG,
   LOGIN_FAILED,
   NOT_EXISTING_DIRECTORY,
   VENDOR_DOWN,
   USER_ACTION_NEEDED,
   FILE_DOWNLOAD_FAILED,
-  requireTwoFactor: requireTwoFactor,
   SAVE_FILE_FAILED
 }

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -145,6 +145,10 @@ const saveEntry = function(entry, options) {
       return options.postProcess ? options.postProcess(entry) : entry
     })
     .catch(err => {
+      if (err.statusCode === 413) {
+        // the cozy quota is full
+        throw new Error(errors.DISK_QUOTA_EXCEEDED)
+      }
       log('warn', errors.SAVE_FILE_FAILED)
       log(
         'warn',

--- a/packages/cozy-konnector-libs/yarn.lock
+++ b/packages/cozy-konnector-libs/yarn.lock
@@ -1569,6 +1569,12 @@ cozy-client-js@^0.8.0:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "0.10.4"
 
+cozy-logger@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.1.4.tgz#201132c8d47cc7b64452fe2bed4f24bbb5059a3c"
+  dependencies:
+    json-stringify-safe "5.0.1"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -3745,7 +3751,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.1, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 


### PR DESCRIPTION
There are a lot of `{"errors":[{"status":"413","title":"Request Entity Too Large","detail":"The file is too big and exceeds the disk quota","source":{}}]}` in the connector logs and the user only gets a generic error message for this.

This also needs an update in cozy-collect locales to allow the user to see the message : https://github.com/cozy/cozy-collect/pull/683