### PR TITLE
fix: Assume default form's action is current url

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/signin.js
+++ b/packages/cozy-konnector-libs/src/libs/signin.js
@@ -76,7 +76,7 @@ module.exports = function signin (
   }).catch(handleRequestErrors)
     .then($ => {
       const data = (typeof formData === 'function' ? formData($) : formData)
-      const [action, inputs] = parseForm($, formSelector)
+      const [action, inputs] = parseForm($, formSelector, url)
       for (let name in data) {
         inputs[name] = data[name]
       }
@@ -112,17 +112,12 @@ function getStrategy (parseStrategy) {
   }
 }
 
-function parseForm ($, formSelector) {
+function parseForm ($, formSelector, currentUrl) {
   const form = $(formSelector).first()
-  const action = form.attr('action')
+  const action = form.attr('action') || currentUrl
 
   if (!form.is('form')) {
     const err = 'element matching `' + formSelector + '` is not a `form`'
-    log('error', err)
-    throw new Error('INVALID_FORM')
-  }
-  if (action === undefined) {
-    const err = 'form matching `' + formSelector + '` has no `action` attribute'
     log('error', err)
     throw new Error('INVALID_FORM')
   }

--- a/packages/cozy-konnector-libs/src/libs/signin.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/signin.spec.js
@@ -33,6 +33,13 @@ describe('signin', () => {
     })
   })
 
+  describe('without action', () => {
+    it('works', () => {
+      return expect(signin({url, formSelector: '#got-no-action', parse: 'raw'}))
+        .resolves.toEqual(resp)
+    })
+  })
+
   describe('url', () => {
     it('throws if missing', () => {
       return expect(() => {
@@ -50,11 +57,6 @@ describe('signin', () => {
 
     it('throws when matching something else than a form', () => {
       return expect(signin({url, formSelector: '#im-no-form', parse: 'raw'}))
-        .rejects.toThrow('INVALID_FORM')
-    })
-
-    it('throws when matching a form without action', () => {
-      return expect(signin({url, formSelector: '#got-no-action', parse: 'raw'}))
         .rejects.toThrow('INVALID_FORM')
     })
 


### PR DESCRIPTION
In signin helper (cozy-konnector-libs), when parsing the signin form,
function was failing if no `action` was specified. HTML spec specifies
that action is optional. If it's empty string, it should be the
document's URL of the form.

Spec: https://www.w3.org/TR/html5/sec-forms.html#form-submission-algorithm