### PR TITLE
fix: allow linkBankOperation to work in standalone mode

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -143,6 +143,12 @@ class Linker {
     return bluebird.each(bills, bill => {
       const res = result[bill._id] = { bill:bill }
 
+      // the bills combination phase is very time consuming. We can avoid it when we run the
+      // connector in standalone mode
+      if (allOperations.length === 0) {
+        return result
+      }
+
       const linkBillToDebitOperation = () => {
         return findDebitOperation(this.cozyClient, bill, options, allOperations)
           .then(operation => {

--- a/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/operationsFilters.js
+++ b/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/operationsFilters.js
@@ -120,7 +120,6 @@ const operationsFilters = (bill, operations, options) => {
     conditions.push(fbyIdentifiers)
   }
 
-  console.log('operation filters starts with', operations.length, 'operations')
   return operations.filter(filterByConditions(conditions))
 }
 

--- a/packages/cozy-konnector-libs/src/libs/utils.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.js
@@ -1,7 +1,13 @@
 const cozyClient = require('./cozyclient')
 
 const fetchAll = async doctype => {
-  const res = await cozyClient.fetchJSON('GET', `/data/${doctype}/_all_docs?include_docs=true`)
+  const res = await cozyClient.fetchJSON(
+    'GET',
+    `/data/${doctype}/_all_docs?include_docs=true`
+  )
+
+  if (!(res && res.rows)) return []
+
   return res.rows
     .filter(doc => doc.id.indexOf('_design') === -1)
     .map(doc => doc.doc)


### PR DESCRIPTION
When running a connector in standalone mode (ex : https://github.com/konnectors/cozy-konnector-template/pull/74) we have an error since there is no bank operation.

fixes #203 