### PR TITLE
print in console the url of the oauth modal

### DIFF
--- a/packages/cozy-jobs-cli/src/cozy-authenticate.js
+++ b/packages/cozy-jobs-cli/src/cozy-authenticate.js
@@ -25,6 +25,8 @@ function onRegistered (client, url) {
     server.listen(3333, () => {
       require('opn')(url, {wait: false})
       console.log('A new tab just opened in your browser to require the right authorizations for this connector in your cozy. Waiting for it...')
+      console.log('If your browser does not open (maybe your are in a headless virtual machine...), then past this url in your browser')
+      console.log(url)
     })
   })
   .then((url) => {


### PR DESCRIPTION
If the script is run in a headless virtual machine, then the autorization oauth modal won't open.
The solution is to manually open a browser with the url loged in the console.