### PR TITLE
🐝 fix: do not truncate rewrite if content is already there. prevents jest watch from infinite restart

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -30,14 +30,9 @@ if (fs.existsSync(KONNECTOR_DEV_CONFIG_PATH)) {
 const ensureImportedDataExists = () => {
   // Truncate dump file
   const initialContent = '[]'
-  const write = () => fs.writeFileSync(DUMP_PATH, initialContent, 'utf8');
-  try {
-    const content = fs.readFileSync(DUMP_PATH).toString()
-    if (content !== initialContent) {
-      write()
-    }
-  } catch (e) {
-    write()
+  const importedDataIsOK = fs.existsSync(DUMP_PATH) && fs.readFileSync(DUMP_PATH).toString() === initialContent
+  if (!importedDataIsOK) {
+    fs.writeFileSync(DUMP_PATH, initialContent, 'utf8')
   }
 }
 

--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -26,8 +26,22 @@ if (fs.existsSync(KONNECTOR_DEV_CONFIG_PATH)) {
     DUMP_PATH
   )
 }
-// Truncate dump file
-fs.writeFileSync(DUMP_PATH, '[]', 'utf8')
+
+const ensureImportedDataExists = () => {
+  // Truncate dump file
+  const initialContent = '[]'
+  const write = () => fs.writeFileSync(DUMP_PATH, initialContent, 'utf8');
+  try {
+    const content = fs.readFileSync(DUMP_PATH).toString()
+    if (content !== initialContent) {
+      write()
+    }
+  } catch (e) {
+    write()
+  }
+}
+
+ensureImportedDataExists()
 
 function loadImportedDataJSON() {
   let docStore = []


### PR DESCRIPTION
Rewriting the file every time the module was imported would lead `jest --watch` to infinite loop.