### PR TITLE
fix: allow requestFactory to be called without argument

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/request/request.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.js
@@ -55,7 +55,7 @@ exports = module.exports = {
   getRequestOptions
 }
 
-function requestFactory({ debug, ...options }) {
+function requestFactory({ debug, ...options } = { debug: false }) {
   debug && requestdebug(request)
   return request.defaults(getRequestOptions(mergeDefaultOptions(options)))
 }


### PR DESCRIPTION
Or else, when we call requestFactory like this:

```js
const request = requestFactory()
```

We get a nasty error