### PR TITLE
feat: add a global openInBrowser command in standalone, dev and shell commands

### DIFF
--- a/packages/cozy-jobs-cli/src/cozy-authenticate.js
+++ b/packages/cozy-jobs-cli/src/cozy-authenticate.js
@@ -33,7 +33,7 @@ function onRegistered(client, url) {
         'A new tab just opened in your browser to require the right authorizations for this connector in your cozy. Waiting for it...'
       )
       console.log(
-        'If your browser does not open (maybe your are in a headless virtual machine...), then past this url in your browser'
+        'If your browser does not open (maybe your are in a headless virtual machine...), then paste this url in your browser'
       )
       console.log(url)
     })

--- a/packages/cozy-jobs-cli/src/dev.js
+++ b/packages/cozy-jobs-cli/src/dev.js
@@ -10,6 +10,7 @@ process.env.COZY_URL = config.COZY_URL
 const program = require('commander')
 const path = require('path')
 const fs = require('fs')
+require('./open-in-browser')
 
 const authenticate = require('./cozy-authenticate')
 

--- a/packages/cozy-jobs-cli/src/open-in-browser.js
+++ b/packages/cozy-jobs-cli/src/open-in-browser.js
@@ -1,0 +1,26 @@
+/* eslint no-console: off */
+
+const opn = require('opn')
+const os = require('os')
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Save the given html or cheerio object in tmp file and open it in the browser
+ */
+global.openInBrowser = $ => {
+  let html = null
+
+  if (typeof $ === 'string') {
+    html = $
+  } else if ($ && $.html()) {
+    html = $.html()
+  } else {
+    throw new Error(`Invalid html or cheerio object given to openInBrowser`)
+  }
+
+  const tmpFile = path.join(os.tmpdir(), 'cozy-run-standalone-open-file.html')
+  fs.writeFileSync(tmpFile, html)
+  opn(tmpFile, { wait: false })
+  console.log(`${tmpFile} should be opened in your browser...`)
+}

--- a/packages/cozy-jobs-cli/src/shell.js
+++ b/packages/cozy-jobs-cli/src/shell.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 const path = require('path')
 const pretty = require('pretty')
 const highlight = require('cli-highlight').highlight
+require('./open-in-browser')
 
 process.env.NODE_ENV = 'standalone'
 if (!process.env.DEBUG) process.env.DEBUG = '*'

--- a/packages/cozy-jobs-cli/src/standalone.js
+++ b/packages/cozy-jobs-cli/src/standalone.js
@@ -3,6 +3,7 @@
 const program = require('commander')
 const fs = require('fs')
 const path = require('path')
+require('./open-in-browser')
 
 program
   .usage('[options] <file>')

--- a/packages/cozy-konnector-libs/docs/cli.md
+++ b/packages/cozy-konnector-libs/docs/cli.md
@@ -1,7 +1,7 @@
 ### CLI
 
 There is a specific npm package which provides cli tools to allow to run your connector in
-standalone or development mode : cozy-jobs-cli. You can install it in your connector as a dev
+standalone or development mode or in dedicated REPL : cozy-jobs-cli. You can install it in your connector as a dev
 dependency.
 
 #### cozy-run-standalone
@@ -30,6 +30,10 @@ defined in `package.json` `main` section or ./src/index.js
 
 It is possible to record and replay the requests done by the standalone command using the
 [replay](https://github.com/assaf/node-replay) module.
+
+When your connector is run with this command, a global function is available in your connector :
+`global.openInBrowser`, which can take an html string or a cheerio object as input and will show
+the corresponding html page in your default browser.
 
 ##### Arguments
 
@@ -73,6 +77,10 @@ The files are saved in the root directory of your cozy by default.
 
 It is also possible to add an argument to this command which tells which file to run. Default is
 defined in `package.json` `main` section or ./src/index.js
+
+When your connector is run with this command, a global function is available in your connector :
+`global.openInBrowser`, which can take an html string or a cheerio object as input and will show
+the corresponding html page in your default browser.
 
 
 ##### Arguments
@@ -141,6 +149,9 @@ yarn shell index.html
 ```
 
 The html file will load and $ will be correctly initialized.
+
+The `openInBrowser` is also available , which can take an html string or a cheerio object as input and will show
+the corresponding html page in your default browser.
 
 ##### Arguments
 


### PR DESCRIPTION
A new openInBrowser global function is available in cozy-run-standalone, cozy-run-dev and cozy-run-shell contexts which take html string or cheerio object as
input, save it in tmp dir and opens it in default browser, which may be useful for debugging