### PR TITLE
feat(cozy-konnector-libs): Clean dist directoring before transpiling

### DIFF
--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "build": "npm run transpile",
-    "transpile": "babel src --out-dir dist",
+    "transpile": "rm -r dist/* ; babel src --out-dir dist",
     "prepublishOnly": "yarn run transpile",
     "test": "cross-env LOG_LEVEL=info jest",
     "doc": "jsdoc2md --template jsdoc2md/README.hbs src/libs/*.js src/helpers/*.js > docs/api.md"


### PR DESCRIPTION
I propose to force the deleting of dist directory data when transpiling.
Because babel only update files, you can keep old file and lead to buggy thing (case with new request.js directory)

What do you think about it ?