### PR TITLE
feat: allow signin to use a specified request instance

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/signin.js
+++ b/packages/cozy-konnector-libs/src/libs/signin.js
@@ -61,7 +61,7 @@ module.exports = function signin({
     throw 'signin: `formSelector` must be defined'
   }
 
-  const rq = requestFactory({
+  const rq = requestOpts.requestInstance || requestFactory({
     jar: true,
     ...requestOpts
   })


### PR DESCRIPTION
The signin function can now take a requestInstance option with the request-promise instance it will
use to do its own requests