### PR TITLE
feat: Log matching bills' vendor and amount

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -159,7 +159,9 @@ class Linker {
               res.debitOperation = operation
               log(
                 'debug',
-                `bills: Matching bill ${bill.subtype} (${fmtDate(
+                `bills: Matching bill ${bill.vendor} ${
+                  bill.amount
+                }${bill.currency || '€'} (${fmtDate(
                   bill.date
                 )}) with debit operation ${operation.label} (${fmtDate(
                   operation.date


### PR DESCRIPTION
Previously, we logged the subtype of the bill. But every bill doesn't have a subtype, and it seems more informatique to know the vendor and the amount of a bill that its subtype.