### PR TITLE
Update group matching

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -280,7 +280,7 @@ class Linker {
       moment(bill.originalDate)
         .format()
         .split('T')[0],
-      bill.type
+      bill.vendor
     ])
 
     return Object.values(groups)

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -36,6 +36,7 @@ class Linker {
   constructor(cozyClient) {
     this.cozyClient = cozyClient
     this.toUpdate = []
+    this.groupVendors = ['Numéricable']
   }
 
   addBillToOperation(bill, operation) {
@@ -217,9 +218,7 @@ class Linker {
         do {
           found = false
 
-          const unlinkedBills = this.getUnlinkedBills(result).filter(
-            bill => bill.type === 'health_costs'
-          )
+          const unlinkedBills = this.getUnlinkedBills(result)
           const billsGroups = this.groupBills(unlinkedBills)
 
           const combinations = flatten(
@@ -275,8 +274,15 @@ class Linker {
     return unlinkedBills
   }
 
+  billCanBeGrouped(bill) {
+    return (
+      bill.type === 'health_costs' || this.groupVendors.includes(bill.vendor)
+    )
+  }
+
   groupBills(bills) {
-    const groups = groupBy(bills, bill => [
+    const billsToGroup = bills.filter(bill => this.billCanBeGrouped(bill))
+    const groups = groupBy(billsToGroup, bill => [
       moment(bill.originalDate)
         .format()
         .split('T')[0],

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -294,11 +294,11 @@ class Linker {
 
   generateBillsCombinations(bills) {
     const MIN_ITEMS_IN_COMBINATION = 2
-    let combinations = []
+    const combinations = []
 
     for (let n = MIN_ITEMS_IN_COMBINATION; n <= bills.length; ++n) {
       const combinationsN = geco.gen(bills.length, n, bills)
-      combinations = combinations.concat([...combinationsN])
+      combinations.push(...combinationsN)
     }
 
     return combinations

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -373,40 +373,63 @@ describe('linker', () => {
         {
           _id: 'b1',
           originalDate: new Date(2018, 2, 10),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
-        { _id: 'b2', originalDate: new Date(2018, 2, 10), type: 'phone' },
+        {
+          _id: 'b2',
+          originalDate: new Date(2018, 2, 10),
+          vendor: 'Numéricable',
+          type: 'health_costs'
+        },
         {
           _id: 'b3',
           originalDate: new Date(2018, 2, 10),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
         {
           _id: 'b4',
           originalDate: new Date(2018, 2, 15),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
         {
           _id: 'b5',
           originalDate: new Date(2018, 2, 15),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
-        { _id: 'b6', originalDate: new Date(2018, 2, 20), type: 'phone' },
+        {
+          _id: 'b6',
+          originalDate: new Date(2018, 2, 20),
+          vendor: 'Numéricable'
+        },
         {
           _id: 'b7',
           originalDate: new Date(2018, 2, 20),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
-        { _id: 'b8', originalDate: new Date(2018, 2, 20), type: 'phone' },
+        {
+          _id: 'b8',
+          originalDate: new Date(2018, 2, 20),
+          vendor: 'Numéricable'
+        },
         {
           _id: 'b9',
           originalDate: new Date(2018, 2, 20),
+          vendor: 'Ameli',
           type: 'health_costs'
         },
-        { _id: 'b10', originalDate: new Date(2018, 2, 30), type: 'phone' }
+        {
+          _id: 'b10',
+          originalDate: new Date(2018, 2, 30),
+          vendor: 'Numéricable'
+        }
       ]
 
-      it('groups bills by type and originalDate', () => {
+      it('groups bills by vendor and originalDate', () => {
         const result = linker.groupBills(bills)
 
         expect(result).toContainEqual([bills[0], bills[2]])


### PR DESCRIPTION
Before, only health bills were grouped to try to match them with grouped debits. But there are some vendors (like Numéricable) that also do grouped debits.

So we did two things here:

* Update the properties we group bills on : now we group on date and vendor, instead of date and type
* Add an array of vendor that do grouped debits : this way we don't consume RAM to group bills of vendors that don't do grouped debits

The only thing that seems crappy is that we have a hardcoded array of vendors names that do grouped debits. If you think about a better solution for that, I would be happy to read it ! But since in a near future this code will be put in a cozy-banks' service, it is not so problematic.

Here is the result in the visualizer:
![image](https://user-images.githubusercontent.com/1606068/42378949-71795918-8129-11e8-87d3-0a883ac73131.png)
