### PR TITLE
fix: change saveFiles default requestFactory options

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -56,7 +56,9 @@ const downloadEntry = function(entry, options) {
 
   const rq = requestFactory({
     json: false,
-    cheerio: false
+    cheerio: false,
+    userAgent: true,
+    jar: true
   })
   let filePromise = rq(reqOptions)
 


### PR DESCRIPTION
Now saveFiles will use default user agent and default cookie jar activated. This corresponds to a
more general use case. This behavior can be deactivated in connector's code if needed :

```javascript
saveFiles([{
  requestOptions: {
    headers: {},
    jar: null
  }
}])
```

This avoids to do https://github.com/konnectors/cozy-konnector-mgen/pull/91/files in connector's
code