### PR TITLE
tests: Add real test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,11 @@
     "lint": "eslint . --fix",
     "test": "cross-env LOG_LEVEL=info jest"
   },
+  "jest": {
+    "testPathIgnorePatterns" : [
+      "<rootDir>/node_modules/",
+      "<rootDir>/packages/.*/dist"
+    ]
+  },
   "dependencies": {}
 }

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -343,6 +343,16 @@ describe('linker', () => {
           })
         })
     })
+
+    it('should not link twice', async () => {
+      const test = tests[0]
+      const options = { ...defaultOptions, ...test.options }
+      expect(operationsById.medecin.reimbursements).toBe(undefined)
+      await linker.linkBillsToOperations(test.bills, options)
+      expect(operationsById.medecin.reimbursements.length).toBe(1)
+      await linker.linkBillsToOperations(test.bills, options)
+      expect(operationsById.medecin.reimbursements.length).toBe(1)
+    })
   })
 
   describe('linking with combinations', () => {

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -1,6 +1,9 @@
 import { Linker } from './linkBankOperations'
 
 jest.mock('./cozyclient')
+jest.mock('cozy-logger', () => ({
+  namespace: () => () => ({})
+}))
 const cozyClient = require('./cozyclient')
 const indexBy = require('lodash/keyBy')
 

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -289,6 +289,26 @@ describe('linker', () => {
           'trainline | 05-05-2017 | TRAINLINE PARIS | -297 | 400840'
         ],
         result: ['b1 | debitOperation | trainline']
+      },
+      {
+        description:
+          'should not link bills with operation that have not the right originalAmount',
+        options: {
+          identifiers: ['CPAM']
+        },
+        bills: [
+          'b1 | 16.1 | 14.6 | 100 | 11-04-2018 | 13-04-2018 | true | Ameli | health'
+        ],
+        dbOperations: [
+          'cohen         | 12-04-2018 | SELARL DR COHEN         | -150 | 400610',
+          'reimbursement | 16-04-2018 | CPAM DES HAUTS DE SEINE | 14.6 | 400610'
+        ],
+        result: ['b1 | creditOperation | reimbursement'],
+        operations: {
+          cohen: {
+            bills: undefined
+          }
+        }
       }
     ]
 
@@ -358,7 +378,10 @@ describe('linker', () => {
         for (let [operationId, matchObject] of Object.entries(
           test.operations || {}
         )) {
-          expect(operationsById[operationId]).toMatchObject(matchObject)
+          const op = operationsById[operationId]
+          for (let [attr, value] of Object.entries(matchObject)) {
+            expect(op).toHaveProperty(attr, value)
+          }
         }
         if (test.extra) {
           test.extra(result)

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -232,9 +232,7 @@ describe('linker', () => {
       {
         description: 'malakoff real case',
         options: {
-          identifiers: ['CPAM', 'Malakoff'],
-          pastWindow: 5,
-          futureWindow: 5
+          identifiers: ['CPAM', 'Malakoff']
         },
         bills: [
           'b1 | 5.9  |  | 45 | 09-01-2018 | 09-01-2018 | true | Ameli    | health_costs',
@@ -268,9 +266,7 @@ describe('linker', () => {
           'harmonie_reimbur | 24-05-2018 | HARMONIE MUTUELLE IP0169697530 MUTUELLE -609143-4152-20970487 | 6.9 | 400610'
         ],
         options: {
-          identifiers: ['Harmonie'],
-          pastWindow: 15,
-          futureWindow: 15
+          identifiers: ['Harmonie']
         },
         result: [
           'harmonie_bill | debitOperation | ophtalmo',
@@ -339,8 +335,8 @@ describe('linker', () => {
     const defaultOptions = {
       minAmountDelta: 1,
       maxAmountDelta: 1,
-      pastWindow: 2,
-      futureWindow: 2
+      pastWindow: 15,
+      futureWindow: 29
     }
 
     function updateOperation(doctype, needleOp, attributes) {

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -270,6 +270,56 @@ describe('linker', () => {
         result: () => ({
           b2: { debitOperation: operationsById.small_sfr }
         })
+      },
+      {
+        description: 'malakoff real case',
+        options: {
+          identifiers: ['CPAM', 'Malakoff'],
+          pastWindow: 5,
+          futureWindow: 5
+        },
+        bills: [
+          'b1 | 5.9  |  | 45 | 09-01-2018 | 09-01-2018 | true | Ameli    | health_costs',
+          'b2 | 13.8 |  | 45 | 15-01-2018 | 15-01-2018 | true | Malakoff | health_costs'
+        ],
+        dbOperations: [
+          'malakoff | 15-01-2018 | Malakoff Mederic Pre | 13.8 | 400610',
+          'cpam     | 12-01-2018 | Cpam de Paris        | 5.9  | 400610',
+          'docteur  | 09-01-2018 | Docteur Konqui       | -45  | 400610'
+        result: () => ({}),
+        ],
+        operations: {
+          docteur: {
+            reimbursements: [
+              {
+                billId: 'io.cozy.bills:b1',
+                amount: 5.9,
+                operationId: 'cpam'
+              }
+            ]
+          }
+        }
+      },
+      {
+        description: 'harmonie real case',
+        bills: [
+          'harmonie_bill | 6.9 | 6.9 | 80 | 23-05-2018 | 16-05-2018 | true | Harmonie | health_costs'
+        ],
+        dbOperations: [
+          'ophtalmo         | 22-05-2018 | CENTRE OPHTALM                                                | -80 | 400610',
+          'harmonie_reimbur | 24-05-2018 | HARMONIE MUTUELLE IP0169697530 MUTUELLE -609143-4152-20970487 | 6.9 | 400610'
+        ],
+        options: {
+          identifiers: ['Harmonie'],
+          pastWindow: 15,
+          futureWindow: 15
+        },
+        result: () => ({
+          harmonie_bill: {
+            debitOperation: operationsById.ophtalmo,
+            creditOperation: operationsById.harmonie_reimbur
+          }
+        })
       }
     ]
 

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -138,45 +138,6 @@ describe('linker', () => {
   })
 
   describe('linkBillsToOperations', () => {
-    const operationsInit = [
-      'medecin   | 13-12-2017 | Visite chez le médecin            | -20  | 400610',
-      'cpam      | 15-12-2017 | Remboursement CPAM                | 5    | 400610',
-      'big_sfr   | 08-12-2017 | Facture SFR                       | -120',
-      'small_sfr | 07-12-2017 | Facture SFR                       | -30',
-      "escalade  | 07-12-2017 | Remboursement Matériel d'escalade | 30",
-      'burrito   | 05-12-2017 | Burrito                           | -5.5',
-      'salade    | 06-12-2017 | Salade                            | -2.6'
-    ].map(parseOperationLine)
-
-    let operations, operationsById
-
-    beforeEach(function() {
-      // reset operations to operationsInit values
-      operations = operationsInit.map(op => ({ ...op }))
-      operationsById = indexBy(operations, '_id')
-      cozyClient.fetchJSON = jest
-        .fn()
-        .mockImplementation(() =>
-          Promise.resolve(wrapAsFetchJSONResult(operations))
-        )
-      linker.updateAttributes.mockImplementation(updateOperation)
-    })
-
-    const defaultOptions = {
-      minAmountDelta: 1,
-      maxAmountDelta: 1,
-      pastWindow: 2,
-      futureWindow: 2
-    }
-
-    function updateOperation(doctype, needleOp, attributes) {
-      const operation = operations.find(
-        operation => operation._id === needleOp._id
-      )
-      Object.assign(operation, attributes)
-      return Promise.resolve(operation)
-    }
-
     const tests = [
       {
         description: 'health bills with both credit and debit',
@@ -330,6 +291,45 @@ describe('linker', () => {
         result: ['b1 | debitOperation | trainline']
       }
     ]
+
+    const operationsInit = [
+      'medecin   | 13-12-2017 | Visite chez le médecin            | -20  | 400610',
+      'cpam      | 15-12-2017 | Remboursement CPAM                | 5    | 400610',
+      'big_sfr   | 08-12-2017 | Facture SFR                       | -120',
+      'small_sfr | 07-12-2017 | Facture SFR                       | -30',
+      "escalade  | 07-12-2017 | Remboursement Matériel d'escalade | 30",
+      'burrito   | 05-12-2017 | Burrito                           | -5.5',
+      'salade    | 06-12-2017 | Salade                            | -2.6'
+    ].map(parseOperationLine)
+
+    let operations, operationsById
+
+    beforeEach(function() {
+      // reset operations to operationsInit values
+      operations = operationsInit.map(op => ({ ...op }))
+      operationsById = indexBy(operations, '_id')
+      cozyClient.fetchJSON = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(wrapAsFetchJSONResult(operations))
+        )
+      linker.updateAttributes.mockImplementation(updateOperation)
+    })
+
+    const defaultOptions = {
+      minAmountDelta: 1,
+      maxAmountDelta: 1,
+      pastWindow: 2,
+      futureWindow: 2
+    }
+
+    function updateOperation(doctype, needleOp, attributes) {
+      const operation = operations.find(
+        operation => operation._id === needleOp._id
+      )
+      Object.assign(operation, attributes)
+      return Promise.resolve(operation)
+    }
 
     for (let test of tests) {
       const fn = test.fn || it

--- a/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/index.js
+++ b/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/index.js
@@ -14,7 +14,6 @@ const findOperation = (cozyClient, bill, options, allOperations) => {
   ).then(operations => {
     operations = operationsFilters(bill, operations, options)
     operations = sortedOperations(bill, operations)
-
     return operations[0]
   })
 }

--- a/packages/cozy-konnector-libs/src/libs/testUtils.js
+++ b/packages/cozy-konnector-libs/src/libs/testUtils.js
@@ -1,0 +1,65 @@
+const parseDate = str => {
+  const [day, month, year] = str.split('-').map(x => parseInt(x, 10))
+  try {
+    return new Date(year, month - 1, day).toISOString()
+  } catch (e) {
+    console.warn(`${str} is not a valid date`)
+    throw e
+  }
+}
+
+const parseAmount = x => parseFloat(x, 10)
+const parseBool = x => x == 'true' ? true : false
+const parseStr = x => x
+
+const operationLineSpec = [
+  ['_id', parseStr],
+  ['date', parseDate],
+  ['label', parseStr],
+  ['amount', parseAmount],
+  ['automaticCategoryId', parseStr]
+]
+
+const billLineSpec = [
+  ['_id', parseStr],
+  ['amount', parseAmount],
+  ['groupAmount', parseAmount],
+  ['originalAmount', parseAmount],
+  ['originalDate', parseDate],
+  ['date', parseDate],
+  ['isRefund', parseBool],
+  ['vendor', parseStr],
+  ['type', parseStr],
+]
+
+const mkLineParser = spec => line => {
+  const splitted = line.split(/\s*\|\s*/)
+  const obj = {}
+  try {
+    spec.forEach(([attr, parser], i) => {
+      if (splitted[i] !== 'undefined' && splitted[i] && splitted[i].length) {
+        obj[attr] = parser(splitted[i])
+      }
+    })
+  } catch (e) {
+    console.warn('Error while parsing', line, e)
+    throw e
+  }
+  return obj
+}
+
+const parseBillLine = mkLineParser(billLineSpec)
+const parseOperationLine = mkLineParser(operationLineSpec)
+
+const wrapAsFetchJSONResult = documents => {
+  return {
+    rows: documents.map(x => {
+      if (!x._id) {
+        throw new Error('doc without id' + x)
+      }
+      return { id: x._id, doc: x }
+    })
+  }
+}
+
+module.exports = { parseBillLine, parseOperationLine, wrapAsFetchJSONResult }

--- a/packages/cozy-konnector-libs/src/libs/testUtils.js
+++ b/packages/cozy-konnector-libs/src/libs/testUtils.js
@@ -33,6 +33,9 @@ const billLineSpec = [
 ]
 
 const mkLineParser = spec => line => {
+  if (typeof line !== 'string') {
+    return line
+  }
   const splitted = line.split(/\s*\|\s*/)
   const obj = {}
   try {

--- a/packages/cozy-konnector-libs/src/libs/testUtils.js
+++ b/packages/cozy-konnector-libs/src/libs/testUtils.js
@@ -3,13 +3,13 @@ const parseDate = str => {
   try {
     return new Date(year, month - 1, day).toISOString()
   } catch (e) {
-    console.warn(`${str} is not a valid date`)
+    console.warn(`${str} is not a valid date`) // eslint-disable-line no-console
     throw e
   }
 }
 
 const parseAmount = x => parseFloat(x, 10)
-const parseBool = x => x == 'true' ? true : false
+const parseBool = x => (x == 'true' ? true : false)
 const parseStr = x => x
 
 const operationLineSpec = [
@@ -29,7 +29,7 @@ const billLineSpec = [
   ['date', parseDate],
   ['isRefund', parseBool],
   ['vendor', parseStr],
-  ['type', parseStr],
+  ['type', parseStr]
 ]
 
 const mkLineParser = spec => line => {
@@ -45,7 +45,7 @@ const mkLineParser = spec => line => {
       }
     })
   } catch (e) {
-    console.warn('Error while parsing', line, e)
+    console.warn('Error while parsing', line, e) // eslint-disable-line no-console
     throw e
   }
   return obj

--- a/packages/cozy-konnector-libs/src/libs/testUtils.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/testUtils.spec.js
@@ -29,4 +29,3 @@ it('should parse correctly with missing values 2', () => {
   expect(op.amount).toBe(-120)
   expect(op.label).toBe('Facture SFR')
 })
-

--- a/packages/cozy-konnector-libs/src/libs/testUtils.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/testUtils.spec.js
@@ -1,0 +1,32 @@
+const { parseOperationLine, parseBillLine } = require('./testUtils')
+
+it('should parse correctly', () => {
+  const line =
+    'medecin   | 13-11-2017 | Visite chez le médecin            | -20  | 400610'
+  const op = parseOperationLine(line)
+  expect(op._id).toBe('medecin')
+  expect(op.label).toBe('Visite chez le médecin')
+  expect(op.amount).toBe(-20)
+  expect(op.automaticCategoryId).toBe('400610')
+})
+
+it('should parse correctly with missing values', () => {
+  const line =
+    'b1 | 5.9 |     | 20 | 13-12-2017 | 15-12-2017 | true | Ameli | health_costs'
+  const bill = parseBillLine(line)
+  expect(bill._id).toBe('b1')
+  expect(bill.amount).toBe(5.9)
+  expect(bill.groupAmount).toBe(undefined)
+  expect(bill.originalAmount).toBe(20)
+  expect(bill.vendor).toBe('Ameli')
+})
+
+it('should parse correctly with missing values 2', () => {
+  const line =
+    'big_sfr   | 08-12-2017 | Facture SFR                       | -120'
+  const op = parseOperationLine(line)
+  expect(op._id).toBe('big_sfr')
+  expect(op.amount).toBe(-120)
+  expect(op.label).toBe('Facture SFR')
+})
+


### PR DESCRIPTION
In this PR, I refactor the test cases for bank operation <-> bill for the
tests to be written declaratively and I add real test cases for Trainline,
Malakoff and Harmonie.

Declarative tests are more readable and are the first step to have only
text files describing the result, the goal being for the PO to be able
to understand the test cases.