### PR TITLE
feat: persistent cozy-run-standalone

### DIFF
--- a/packages/cozy-jobs-cli/src/standalone.js
+++ b/packages/cozy-jobs-cli/src/standalone.js
@@ -12,6 +12,7 @@ program
     'Record all the requests in the ./fixtures directory using the replay module'
   )
   .option('--replay', 'Replay all the recorded requests')
+  .option('--persist', 'Do not empty ./data/importedData.json at each run')
   .parse(process.argv)
 
 process.env.NODE_ENV = 'standalone'
@@ -22,12 +23,6 @@ if (!fs.existsSync(rootPath)) fs.mkdirSync(rootPath)
 process.env.COZY_FIELDS = JSON.stringify({
   folder_to_save: rootPath
 })
-
-// ensure the importedData.json file exist or is initialized with default content
-let DUMP_PATH = path.join(rootPath, 'importedData.json')
-const initialContent = '[]'
-if (!fs.existsSync(DUMP_PATH))
-  fs.writeFileSync(DUMP_PATH, initialContent, 'utf8')
 
 const config = require('./init-konnector-config')()
 process.env.COZY_URL = config.COZY_URL

--- a/packages/cozy-konnector-libs/.gitignore
+++ b/packages/cozy-konnector-libs/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+importedData.json

--- a/packages/cozy-konnector-libs/docs/cli.md
+++ b/packages/cozy-konnector-libs/docs/cli.md
@@ -45,6 +45,7 @@ Options:
 
   --record  Record all the requests in the ./fixtures directory using the replay module
   --replay  Replay all the recorded requests
+  --persist Do not empty ./data/importedData.json at each run
   -h, --help  output usage information
 ```
 

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -27,13 +27,14 @@
     "date-fns": "1.29.0",
     "geco": "0.11.1",
     "lodash": "4.17.10",
+    "lodash-id": "^0.14.0",
+    "lowdb": "^1.0.0",
     "moment": "2.22.2",
     "pdfjs": "2.0.0",
     "raven": "2.6.3",
     "request": "2.87.0",
     "request-debug": "0.2.0",
-    "request-promise": "4.2.2",
-    "uuid": "3.3.2"
+    "request-promise": "4.2.2"
   },
   "scripts": {
     "build": "npm run transpile",

--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.spec.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.spec.js
@@ -1,0 +1,96 @@
+const fs = require('fs')
+const stub = require('./cozy-client-js-stub')
+fs.unlinkSync('importedData.json')
+
+const low = require('lowdb')
+const lodashId = require('lodash-id')
+const Memory = require('lowdb/adapters/Memory')
+const omit = require('lodash/omit')
+
+describe('cozy-client-js-stub', () => {
+  const db = low(new Memory())
+  db._.mixin(lodashId)
+  db._.id = '_id'
+  stub._setDb(db)
+  beforeEach(() => {
+    db.setState({})
+  })
+
+  it('should create a doc in a given doctype', async () => {
+    await stub.data.create('io.cozy.bills', { toto: 'test' })
+    expect(
+      db
+        .get('io.cozy.bills')
+        .first()
+        .omit('_id')
+        .value()
+    ).toEqual({ toto: 'test' })
+  })
+  it('should update attributes of a given document', async () => {
+    db.defaults({ 'io.cozy.bills': [] }).write()
+    const doc = db
+      .get('io.cozy.bills')
+      .insert({ test: 'toto' })
+      .write()
+    await stub.data.updateAttributes('io.cozy.bills', doc._id, {
+      test: 'updated',
+      newattr: 'value'
+    })
+    expect(
+      db
+        .get('io.cozy.bills')
+        .first()
+        .omit('_id')
+        .value()
+    ).toEqual({ test: 'updated', newattr: 'value' })
+  })
+  it('should query documents with given attributes', async () => {
+    db.defaults({ 'io.cozy.bills': [] }).write()
+    const bills = db.get('io.cozy.bills')
+    bills.insert({ mandatory: 'toto' }).write()
+    bills.insert({ otherattr: 'toto' }).write()
+    bills.insert({ mandatory: 'titi' }).write()
+    const index = await stub.data.defineIndex('io.cozy.bills')
+    const result = await stub.data.query(index, {
+      selector: {
+        mandatory: { $gt: null }
+      }
+    })
+    expect(result.map(doc => omit(doc, '_id'))).toEqual([
+      { mandatory: 'toto' },
+      { mandatory: 'titi' }
+    ])
+  })
+  it('should get all element of a doctype', async () => {
+    db.defaults({ 'io.cozy.bills': [] }).write()
+    const bills = db.get('io.cozy.bills')
+    bills.insert({ mandatory: 'toto' }).write()
+    bills.insert({ otherattr: 'toto' }).write()
+    bills.insert({ mandatory: 'titi' }).write()
+    const result = await stub.data.findAll('io.cozy.bills')
+    expect(result.map(doc => omit(doc, '_id'))).toEqual([
+      { mandatory: 'toto' },
+      { otherattr: 'toto' },
+      { mandatory: 'titi' }
+    ])
+  })
+  it('should remove an element from a doctype', async () => {
+    db.defaults({ 'io.cozy.bills': [] }).write()
+    const bills = db.get('io.cozy.bills')
+    bills.insert({ mandatory: 'toto' }).write()
+    bills.insert({ otherattr: 'toto' }).write()
+    const doc = bills.insert({ mandatory: 'titi' }).write()
+    await stub.data.delete('io.cozy.bills', doc)
+    const result = bills.value().map(doc => omit(doc, '_id'))
+    expect(result).toEqual([{ mandatory: 'toto' }, { otherattr: 'toto' }])
+  })
+  it('should find a doc in a doctype with its id', async () => {
+    db.defaults({ 'io.cozy.bills': [] }).write()
+    const bills = db.get('io.cozy.bills')
+    const doc = bills.insert({ mandatory: 'toto' }).write()
+    bills.insert({ otherattr: 'toto' }).write()
+    bills.insert({ mandatory: 'titi' }).write()
+    const result = await stub.data.find('io.cozy.bills', doc._id)
+    expect(omit(result, '_id')).toEqual({ mandatory: 'toto' })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3300,7 +3300,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -4856,6 +4856,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-id@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/lodash-id/-/lodash-id-0.14.0.tgz#baf48934e543a1b5d6346f8c84698b1a8c803896"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -4905,7 +4909,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@4.17.10, lodash@^4.15.0, lodash@^4.17.5:
+lodash@4, lodash@4.17.10, lodash@^4.15.0, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4933,6 +4937,16 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lowdb@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowdb/-/lowdb-1.0.0.tgz#5243be6b22786ccce30e50c9a33eac36b20c8064"
+  dependencies:
+    graceful-fs "^4.1.3"
+    is-promise "^2.1.0"
+    lodash "4"
+    pify "^3.0.0"
+    steno "^0.4.1"
 
 lowercase-keys@^1.0.0:
   version "1.0.0"
@@ -7192,6 +7206,12 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+steno@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/steno/-/steno-0.4.4.tgz#071105bdfc286e6615c0403c27e9d7b5dcb855cb"
+  dependencies:
+    graceful-fs "^4.1.3"
+
 stream-connect@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stream-connect/-/stream-connect-1.0.2.tgz#18bc81f2edb35b8b5d9a8009200a985314428a97"
@@ -7919,10 +7939,6 @@ uuid@3.0.0:
 uuid@3.2.1, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 uuid@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
- added --persist option to cozy-run-standalone to allow to keep the state in importedData.json run
  after run
- "better" stub db implementation using lowdb to allow the hydrateAndFilter function to work in
  standalone mode
- unit tests for cozy-client-js-stub