### PR TITLE
fix(requestFactory): do not activate json when cheerio is false by default

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/request/request.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.js
@@ -68,7 +68,11 @@ function mergeDefaultOptions(options = {}) {
     headers: {},
     followAllRedirects: true
   }
-  return { ...defaultOptions, ...options, json: !options.cheerio }
+  if (options.cheerio === true) {
+    options.json = false
+  }
+
+  return { ...defaultOptions, ...options }
 }
 
 function transformWithCheerio(body, response, resolveWithFullResponse) {

--- a/packages/cozy-konnector-libs/src/libs/request/request.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.spec.js
@@ -94,6 +94,13 @@ describe('requestFactory', () => {
       })
       expect(options.json).toBe(false)
     })
+    test('should not activate json when cheerio false', () => {
+      const options = mergeDefaultOptions({
+        cheerio: false,
+        json: false
+      })
+      expect(options.json).toBe(false)
+    })
   })
 
   describe('TLS behavior assertions', () => {


### PR DESCRIPTION
We need to be able to read texts which are not html or json (javascript for example)