### PR TITLE
feat: remove deleted bills from bank operations

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -283,6 +283,66 @@ create it&#39;s own index with the keys specified in the selector</li>
 <pre><code class="lang-javascript">const documents = await queryAll(&#39;io.cozy.bills&#39;, {vendor: &#39;Direct Energie&#39;})
 </code></pre>
 </dd>
+<dt><a href="#module_utils">utils</a></dt>
+<dd><p>This function find duplicates in a given doctype, filtered by an optional mango selector</p>
+<p>Parameters:</p>
+<ul>
+<li><code>doctype</code> (string): the doctype from which you want to fetch the data</li>
+<li><code>selector</code> (object): (optional) the mango query selector</li>
+<li><code>options</code> :<ul>
+<li><code>keys</code> (array) : List of keys used to check that two items are the same.</li>
+<li><code>index</code> (optionnal) : Return value returned by <code>cozy.data.defineIndex</code>, the default will correspond to all documents of the selected doctype.</li>
+<li><code>selector</code> (optionnal object) : Mango request to get records. Gets all the records by default</li>
+</ul>
+</li>
+</ul>
+<p>Returns an object with the following keys:</p>
+<ul>
+<li><code>toKeep</code>: this is the list of unique documents that you should keep in db</li>
+<li><code>toRemove</code>: this is the list of documents that can remove from db. If this is io.cozy.bills
+documents, do not forget to clean linked bank operations</li>
+</ul>
+<pre><code class="lang-javascript">const {toKeep, toRemove} = await findDuplicates(&#39;io.cozy.bills&#39;, {selector: {vendor: &#39;Direct Energie&#39;}})
+</code></pre>
+</dd>
+<dt><a href="#module_utils">utils</a></dt>
+<dd><p>This is a shortcut to update multiple documents in one call</p>
+<p>Parameters:</p>
+<ul>
+<li><code>doctype</code> (string): the doctype from which you want to fetch the data</li>
+<li><code>ids</code> (array): array of ids of documents to update</li>
+<li><code>transformation</code> (object): attributes to change with their values</li>
+<li><code>options</code> :<ul>
+<li><code>keys</code> (array) : List of keys used to check that two items are the same.</li>
+<li><code>index</code> (optionnal) : Return value returned by <code>cozy.data.defineIndex</code>, the default will correspond to all documents of the selected doctype.</li>
+<li><code>selector</code> (optionnal object) : Mango request to get records. Gets all the records by default</li>
+</ul>
+</li>
+</ul>
+<p>Returns a promise which resolves with all the return values of updateAttributes</p>
+<pre><code class="lang-javascript">await batchUpdateAttributes(&#39;io.cozy.bills&#39;, [1, 2, 3], {vendor: &#39;Direct Energie&#39;})
+</code></pre>
+</dd>
+<dt><a href="#module_utils">utils</a></dt>
+<dd><p>This is a shortcut to delete multiple documents in one call</p>
+<p>Parameters:</p>
+<ul>
+<li><code>doctype</code> (string): the doctype from which you want to fetch the data</li>
+<li><code>documents</code> (array): documents to delete with their ids</li>
+<li><code>transformation</code> (object): attributes to change with their values</li>
+<li><code>options</code> :<ul>
+<li><code>keys</code> (array) : List of keys used to check that two items are the same.</li>
+<li><code>index</code> (optionnal) : Return value returned by <code>cozy.data.defineIndex</code>, the default will correspond to all documents of the selected doctype.</li>
+<li><code>selector</code> (optionnal object) : Mango request to get records. Gets all the records by default</li>
+</ul>
+</li>
+</ul>
+<p>Returns a promise which resolves with all the return values of updateAttributes</p>
+<p>Example to remove all the documents for a given doctype</p>
+<pre><code class="lang-javascript">const documents = await fetchAll(&#39;io.cozy.marvel&#39;)
+await batchDelete(&#39;io.cozy.marvel&#39;, documents)
+</code></pre>
+</dd>
 </dl>
 
 ## Classes
@@ -705,6 +765,74 @@ create it's own index with the keys specified in the selector
 
 ```javascript
 const documents = await queryAll('io.cozy.bills', {vendor: 'Direct Energie'})
+```
+
+<a name="module_utils"></a>
+
+## utils
+This function find duplicates in a given doctype, filtered by an optional mango selector
+
+Parameters:
+
+* `doctype` (string): the doctype from which you want to fetch the data
+* `selector` (object): (optional) the mango query selector
+* `options` :
+   - `keys` (array) : List of keys used to check that two items are the same.
+   - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
+   - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
+
+Returns an object with the following keys:
+* `toKeep`: this is the list of unique documents that you should keep in db
+* `toRemove`: this is the list of documents that can remove from db. If this is io.cozy.bills
+documents, do not forget to clean linked bank operations
+
+```javascript
+const {toKeep, toRemove} = await findDuplicates('io.cozy.bills', {selector: {vendor: 'Direct Energie'}})
+```
+
+<a name="module_utils"></a>
+
+## utils
+This is a shortcut to update multiple documents in one call
+
+Parameters:
+
+* `doctype` (string): the doctype from which you want to fetch the data
+* `ids` (array): array of ids of documents to update
+* `transformation` (object): attributes to change with their values
+* `options` :
+   - `keys` (array) : List of keys used to check that two items are the same.
+   - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
+   - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
+
+Returns a promise which resolves with all the return values of updateAttributes
+
+```javascript
+await batchUpdateAttributes('io.cozy.bills', [1, 2, 3], {vendor: 'Direct Energie'})
+```
+
+<a name="module_utils"></a>
+
+## utils
+This is a shortcut to delete multiple documents in one call
+
+Parameters:
+
+* `doctype` (string): the doctype from which you want to fetch the data
+* `documents` (array): documents to delete with their ids
+* `transformation` (object): attributes to change with their values
+* `options` :
+   - `keys` (array) : List of keys used to check that two items are the same.
+   - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
+   - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
+
+Returns a promise which resolves with all the return values of updateAttributes
+
+Example to remove all the documents for a given doctype
+
+```javascript
+const documents = await fetchAll('io.cozy.marvel')
+await batchDelete('io.cozy.marvel', documents)
 ```
 
 <a name="BaseKonnector"></a>

--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -56,10 +56,14 @@ module.exports = {
       setDefaults(doctype)
       const { selector } = options
       const keys = Object.keys(selector)
-      const result = db
+      let result = db
         .get(doctype)
         .filter(doc => keys.every(key => doc[key]))
         .value()
+
+      if (options.wholeResponse) {
+        result = { docs: result }
+      }
       return Promise.resolve(result)
     },
     findAll(doctype) {

--- a/packages/cozy-konnector-libs/src/libs/saveBills.js
+++ b/packages/cozy-konnector-libs/src/libs/saveBills.js
@@ -77,8 +77,13 @@ module.exports = (entries, fields, options = {}) => {
   return saveFiles(entries, fields, options)
     .then(entries => hydrateAndFilter(entries, DOCTYPE, options))
     .then(entries => addData(entries, DOCTYPE, options))
-    .then(() => linkBankOperations(originalEntries, DOCTYPE, fields, options))
     .then(() => cleanDuplicates(options, vendor))
+    .then(toRemove => {
+      if (toRemove) {
+        options.billsToRemove = toRemove)
+      }
+      return linkBankOperations(originalEntries, DOCTYPE, fields, options)
+    })
 }
 
 async function cleanDuplicates(options, vendor) {
@@ -99,6 +104,7 @@ async function cleanDuplicates(options, vendor) {
     if (options.removeDuplicates) {
       log('info', 'Removing duplicated bills')
       await batchDelete(DOCTYPE, toRemove)
+      return toRemove
     }
   }
 }

--- a/packages/cozy-konnector-libs/src/libs/saveBills.js
+++ b/packages/cozy-konnector-libs/src/libs/saveBills.js
@@ -80,7 +80,7 @@ module.exports = (entries, fields, options = {}) => {
     .then(() => cleanDuplicates(options, vendor))
     .then(toRemove => {
       if (toRemove) {
-        options.billsToRemove = toRemove)
+        options.billsToRemove = toRemove
       }
       return linkBankOperations(originalEntries, DOCTYPE, fields, options)
     })

--- a/packages/cozy-konnector-libs/src/libs/utils.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.spec.js
@@ -15,7 +15,7 @@ const db = [
 ]
 
 const cozy = require('./cozyclient')
-const { fetchAll, queryAll } = require('./utils')
+const { fetchAll, queryAll, findDuplicates } = require('./utils')
 
 const asyncResolve = data =>
   new Promise(resolve => setImmediate(() => resolve(data)))
@@ -61,7 +61,50 @@ describe('queryAll', () => {
       )
 
     const result = await queryAll('io.cozy.marvel', {})
-
     expect(result).toEqual(db)
+  })
+})
+
+describe('findDuplicates', () => {
+  const db = [
+    { name: 'Thanos', id: 1 },
+    { name: 'Beyonder', id: 2 },
+    { name: 'Beyonder', id: 3 },
+    { name: 'Kubik', id: 4 },
+    { name: 'Kubik', id: 4 },
+    { name: 'Solar', id: 1 },
+    { name: 'Spawn', id: 4 }
+  ]
+
+  it('should find duplicates and uniques', async () => {
+    cozy.fetchJSON.mockReturnValue(
+      asyncResolve({
+        rows: db.map(doc => ({
+          id: '1',
+          doc
+        }))
+      })
+    )
+    const { toKeep, toRemove } = await findDuplicates('io.cozy.marvel', {
+      keys: ['name', 'id']
+    })
+    expect(toKeep).toEqual([
+      { name: 'Thanos', id: 1 },
+      { name: 'Beyonder', id: 2 },
+      { name: 'Beyonder', id: 3 },
+      { name: 'Kubik', id: 4 },
+      { name: 'Solar', id: 1 },
+      { name: 'Spawn', id: 4 }
+    ])
+    expect(toRemove).toEqual([{ name: 'Kubik', id: 4 }])
+  })
+  it('should works with an empty list', async () => {
+    cozy.fetchJSON.mockReturnValue(asyncResolve({ rows: [] }))
+    const { toKeep, toRemove } = await findDuplicates('io.cozy.marvel', {
+      keys: ['name', 'id']
+    })
+
+    expect(toKeep).toEqual([])
+    expect(toRemove).toEqual([])
   })
 })


### PR DESCRIPTION
This PR depends on https://github.com/konnectors/libs/pull/324 which cleans duplicated bills. 
The goal here is to also clean those bills from linked bank operations. This is at the moment only activated when option "removeDuplicate" is set to true to allow us to test it heavily before deploying it in production. 
The cleaning is done in "linkBankOperations" for performance reasons and avoid getting all the operation multiple times. This needs a review from the gangsters especially