### PR TITLE
fix: Re-enable the self-signed cert test as badssl.com is fixed

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/request/request.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.spec.js
@@ -128,7 +128,7 @@ describe('requestFactory', () => {
         new Error('Error: unable to verify the first certificate')
       )
     })
-    test.skip('Self-signed cert should be refused', async () => {
+    test('Self-signed cert should be refused', async () => {
       return expect(rq('https://self-signed.badssl.com')).rejects.toEqual(
         new Error('Error: self signed certificate')
       )


### PR DESCRIPTION
The error on badssl.com website as been fixed.

See : https://github.com/chromium/badssl.com/issues/359
or  https://self-signed.badssl.com/  (correct self-sign error)