### PR TITLE
feat: Use app version as sentry release

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/sentry.js
+++ b/packages/cozy-konnector-libs/src/helpers/sentry.js
@@ -1,4 +1,4 @@
-/* global GIT_SHA */
+/* global __APP_VERSION__ */
 
 const log = require('cozy-logger')
 const Raven = require('raven')
@@ -48,7 +48,8 @@ const afterCaptureException = function(sendErr, eventId) {
 const setupSentry = function() {
   try {
     log('info', 'process.env.SENTRY_DSN found, setting up Raven')
-    const release = typeof GIT_SHA !== 'undefined' ? GIT_SHA : 'dev'
+    const release =
+      typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
     const domain = getDomain()
     const environment = getEnvironmentFromDomain(domain)
     const instance = getInstance()


### PR DESCRIPTION
In sentry, we currently use git commit SHA as release names. It seems clearer to use the app version. This is the subject of this PR.

It is a breaking change since the `GIT_SHA` global is replaced by `__APP_VERSION__`. It would still be provided at build time by webpack ProvidePlugin. But connectors currently using `GIT_SHA` would see all their sentry issues bound to the "dev" release if they don't update the variable name.