### PR TITLE
WIP: fix: keep bills linked to operations if any

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.js
@@ -42,14 +42,19 @@ class Linker {
   }
 
   async removeBillsFromOperations(bills, operations) {
-    const billsOperations = operations.filter(op => op.bills)
-    const ids = bills.map(bill => `io.cozy.bills:${bill._id}`)
     await Promise.all(
-      billsOperations.map(async op => {
-        op.bills = op.bills || []
-        const bills = op.bills.filter(billId => !ids.includes(billId))
-        if (op.bills.length > bills.length) {
-          await this.updateAttributes(DOCTYPE_OPERATIONS, op, { bills })
+      bills.map(async bill => {
+        for (let op of operations) {
+          const billLongId = `io.cozy.bills:${bill._id}`
+          op.bills = op.bills || []
+          // if bill id found in op bills, do something
+          if (op.bills.indexOf(billLongId) >= 0) {
+            let billsAttribut = op.bills.filter(billId => (billId != billLongId))
+            if (bill.original) {
+              billsAttribut.push(`io.cozy.bills:${bill.original}`)
+            }
+            await this.updateAttributes(DOCTYPE_OPERATIONS, op, { bills: billsAttribut })
+          }
         }
       })
     )

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -131,6 +131,24 @@ describe('linker', () => {
         ]
       ])
     })
+    test('bill that bring an original to link in operation', async () => {
+      const operations = [
+        {
+          _id: 1,
+          bills: ['io.cozy.bills:b1']
+        }
+      ]
+      const bills = [{...bill, original: 'b2'}]
+
+      await linker.removeBillsFromOperations(bills, operations)
+      expect(linker.updateAttributes).lastCalledWith(
+        'io.cozy.bank.operations',
+        operations[0],
+        {
+          bills: ['io.cozy.bills:b2']
+        }
+      )
+    })
   })
 
   describe('addBillToOperation', () => {

--- a/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/linkBankOperations.spec.js
@@ -131,7 +131,7 @@ describe('linker', () => {
         ]
       ])
     })
-    test('bill that bring an original to link in operation', async () => {
+    test('bill with original', async () => {
       const operations = [
         {
           _id: 1,
@@ -139,6 +139,44 @@ describe('linker', () => {
         }
       ]
       const bills = [{...bill, original: 'b2'}]
+
+      await linker.removeBillsFromOperations(bills, operations)
+      expect(linker.updateAttributes).lastCalledWith(
+        'io.cozy.bank.operations',
+        operations[0],
+        {
+          bills: ['io.cozy.bills:b2']
+        }
+      )
+    })
+    test('2 bills with original', async () => {
+      const operations = [
+        {
+          _id: 3,
+          bills: ['io.cozy.bills:b1', 'io.cozy.bills:a1']
+        }
+      ]
+      const bills = [{...bill, original: 'b2'},
+                     {amount: 110, _id: 'a1', original: 'a2'}]
+
+      await linker.removeBillsFromOperations(bills, operations)
+      expect(linker.updateAttributes).lastCalledWith(
+        'io.cozy.bank.operations',
+        operations[0],
+        {
+          bills: ['io.cozy.bills:b2', 'io.cozy.bills:a2']
+        }
+      )
+    })
+    test('bill with original, and original present', async () => {
+      const operations = [
+        {
+          _id: 2,
+          bills: ['io.cozy.bills:b1', 'io.cozy.bills:b2']
+        }
+      ]
+      const bills = [{...bill, original: 'b2'},
+                     {amount: 110, _id: 'a1', original: 'a2'}]
 
       await linker.removeBillsFromOperations(bills, operations)
       expect(linker.updateAttributes).lastCalledWith(

--- a/packages/cozy-konnector-libs/src/libs/utils.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.js
@@ -31,8 +31,7 @@
  * @module filterData
  */
 const cozyClient = require('./cozyclient')
-const uniqBy = require('lodash/uniqBy')
-const differenceBy = require('lodash/differenceBy')
+const groupBy = require('lodash/groupBy')
 const keyBy = require('lodash/keyBy')
 const sortBy = require('lodash/sortBy')
 
@@ -149,8 +148,21 @@ const findDuplicates = async (doctype, options) => {
     documents = sortBillsByLinkedOperationNumber(documents, operations)
   }
 
-  const toKeep = uniqBy(documents, hash)
-  const toRemove = differenceBy(documents, toKeep)
+  const groups = groupBy(documents, hash)
+  const toKeep = []
+  const toRemove = []
+  for (let key in groups) {
+    const group = groups[key]
+    toKeep.push(group[0])
+    toRemove.push.apply(
+      toRemove,
+      group.slice(1).map(doc => ({
+        ...doc,
+        original: group[0]._id
+      }))
+    )
+  }
+
   return { toKeep, toRemove }
 }
 

--- a/packages/cozy-konnector-libs/src/libs/utils.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.spec.js
@@ -15,7 +15,12 @@ const db = [
 ]
 
 const cozy = require('./cozyclient')
-const { fetchAll, queryAll, findDuplicates } = require('./utils')
+const {
+  fetchAll,
+  queryAll,
+  findDuplicates,
+  sortBillsByLinkedOperationNumber
+} = require('./utils')
 
 const asyncResolve = data =>
   new Promise(resolve => setImmediate(() => resolve(data)))
@@ -66,17 +71,17 @@ describe('queryAll', () => {
 })
 
 describe('findDuplicates', () => {
-  const db = [
-    { name: 'Thanos', id: 1 },
-    { name: 'Beyonder', id: 2 },
-    { name: 'Beyonder', id: 3 },
-    { name: 'Kubik', id: 4 },
-    { name: 'Kubik', id: 4 },
-    { name: 'Solar', id: 1 },
-    { name: 'Spawn', id: 4 }
-  ]
-
   it('should find duplicates and uniques', async () => {
+    const db = [
+      { name: 'Thanos', id: 1 },
+      { name: 'Beyonder', id: 2 },
+      { name: 'Beyonder', id: 3 },
+      { name: 'Kubik', id: 4 },
+      { name: 'Kubik', id: 4 },
+      { name: 'Solar', id: 1 },
+      { name: 'Spawn', id: 4 }
+    ]
+
     cozy.fetchJSON.mockReturnValue(
       asyncResolve({
         rows: db.map(doc => ({
@@ -98,7 +103,7 @@ describe('findDuplicates', () => {
     ])
     expect(toRemove).toEqual([{ name: 'Kubik', id: 4 }])
   })
-  it('should works with an empty list', async () => {
+  it('should work with an empty list', async () => {
     cozy.fetchJSON.mockReturnValue(asyncResolve({ rows: [] }))
     const { toKeep, toRemove } = await findDuplicates('io.cozy.marvel', {
       keys: ['name', 'id']
@@ -106,5 +111,84 @@ describe('findDuplicates', () => {
 
     expect(toKeep).toEqual([])
     expect(toRemove).toEqual([])
+  })
+
+  it('should keep linked bills by preference', async () => {
+    const date = new Date()
+    const vendor = 'vendor'
+    const bills = [
+      { amount: 1, date, vendor, _id: 1 },
+      { amount: 2, date, vendor, _id: 2 },
+      { amount: 1, date, vendor, _id: 3 },
+      { amount: 2, date, vendor, _id: 4 },
+      { amount: 1, date, vendor, _id: 5 },
+      { amount: 2, date, vendor, _id: 6 },
+      { amount: 1, date, vendor, _id: 7 },
+      { amount: 2, date, vendor, _id: 8 },
+      { amount: 1, date, vendor, _id: 9 }
+    ]
+    cozy.fetchJSON.mockReturnValueOnce(
+      asyncResolve({
+        rows: bills.map(doc => ({
+          id: '1',
+          doc
+        }))
+      })
+    )
+
+    const operations = [{ bills: [2, 3, 4] }, { bills: [4, 5, 6] }]
+    cozy.fetchJSON.mockReturnValueOnce(
+      asyncResolve({
+        rows: operations.map(doc => ({
+          id: '1',
+          doc
+        }))
+      })
+    )
+
+    const { toKeep } = await findDuplicates('io.cozy.bills', {
+      keys: ['amount']
+    })
+
+    expect(toKeep).toEqual([
+      { amount: 2, date, vendor, _id: 4, opNb: 2 },
+      { amount: 1, date, vendor, _id: 5, opNb: 1 }
+    ])
+  })
+})
+
+describe('sortBillsByLinkedOperationNumber', () => {
+  it('should sort bills by number of linked operations', () => {
+    const date = new Date()
+    const vendor = 'vendor'
+    const bills = [
+      { amount: 1, date, vendor, _id: 1 },
+      { amount: 2, date, vendor, _id: 2 },
+      { amount: 1, date, vendor, _id: 3 },
+      { amount: 2, date, vendor, _id: 4 },
+      { amount: 1, date, vendor, _id: 5 },
+      { amount: 2, date, vendor, _id: 6 },
+      { amount: 1, date, vendor, _id: 7 },
+      { amount: 2, date, vendor, _id: 8 },
+      { amount: 1, date, vendor, _id: 9 }
+    ]
+
+    const operations = [{ bills: [2, 3, 4] }, { bills: [4, 5, 6] }]
+
+    const expected = [
+      { amount: 2, date, vendor, _id: 4, opNb: 2 },
+      { amount: 2, date, vendor, _id: 6, opNb: 1 },
+      { amount: 1, date, vendor, _id: 5, opNb: 1 },
+      { amount: 1, date, vendor, _id: 3, opNb: 1 },
+      { amount: 2, date, vendor, _id: 2, opNb: 1 },
+      { amount: 1, date, vendor, _id: 9, opNb: 0 },
+      { amount: 2, date, vendor, _id: 8, opNb: 0 },
+      { amount: 1, date, vendor, _id: 7, opNb: 0 },
+      { amount: 1, date, vendor, _id: 1, opNb: 0 }
+    ]
+
+    expect(sortBillsByLinkedOperationNumber(bills, operations)).toEqual(
+      expected
+    )
   })
 })

--- a/packages/cozy-konnector-libs/src/libs/utils.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.spec.js
@@ -22,6 +22,8 @@ const {
   sortBillsByLinkedOperationNumber
 } = require('./utils')
 
+const sortBy = require('lodash/sortBy')
+
 const asyncResolve = data =>
   new Promise(resolve => setImmediate(() => resolve(data)))
 
@@ -146,13 +148,22 @@ describe('findDuplicates', () => {
       })
     )
 
-    const { toKeep } = await findDuplicates('io.cozy.bills', {
+    const { toKeep, toRemove } = await findDuplicates('io.cozy.bills', {
       keys: ['amount']
     })
 
-    expect(toKeep).toEqual([
+    expect(sortBy(toKeep, '_id')).toEqual([
       { amount: 2, date, vendor, _id: 4, opNb: 2 },
       { amount: 1, date, vendor, _id: 5, opNb: 1 }
+    ])
+    expect(sortBy(toRemove, '_id')).toEqual([
+      { amount: 1, date, vendor, _id: 1, opNb: 0, original: 5 },
+      { amount: 2, date, vendor, _id: 2, opNb: 1, original: 4 },
+      { amount: 1, date, vendor, _id: 3, opNb: 1, original: 5 },
+      { amount: 2, date, vendor, _id: 6, opNb: 1, original: 4 },
+      { amount: 1, date, vendor, _id: 7, opNb: 0, original: 5 },
+      { amount: 2, date, vendor, _id: 8, opNb: 0, original: 4 },
+      { amount: 1, date, vendor, _id: 9, opNb: 0, original: 5 }
     ])
   })
 })


### PR DESCRIPTION
Here the bills are first ordered by the number of linked operations so that the bills with the most of linked
operation are kept. This is a work in progress and not tested yet.