### PR TITLE
fix: now signin will have json deactivated by default to avoid common errors

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/signin.js
+++ b/packages/cozy-konnector-libs/src/libs/signin.js
@@ -65,6 +65,7 @@ module.exports = function signin({
     requestOpts.requestInstance ||
     requestFactory({
       jar: true,
+      json: false,
       ...requestOpts
     })
 


### PR DESCRIPTION
This will avoid header accept: application/json for html forms. And signin is not especially useful for json apis.