### PR TITLE
fix(BaseKonnector): now use trigger's folder_to_save as reference for the connector folder path

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -141,13 +141,13 @@ class BaseKonnector {
       })
       .then(account => {
         this.fields = Object.assign(
+          account.auth,
+          account.oauth,
           cozyFields.folder_to_save
             ? {
                 folderPath: cozyFields.folder_to_save
               }
-            : {},
-          account.auth,
-          account.oauth
+            : {}
         )
 
         return this.fields


### PR DESCRIPTION
account's folderPath is still used if the trigger has no folder_to_save, which is not supposed to happen
with https://github.com/cozy/cozy-stack/pull/1510