### PR TITLE
fix: handle old oauth accounts

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -89,6 +89,7 @@ class BaseKonnector {
    */
   fail(err) {
     log('warn', 'Error caught by BaseKonnector')
+    log('error', JSON.stringify(err.stack))
 
     const error = err.message || err
 
@@ -144,6 +145,7 @@ class BaseKonnector {
       })
       .then(account => {
         this.fields = Object.assign(
+          {},
           account.auth,
           account.oauth,
           cozyFields.folder_to_save


### PR DESCRIPTION
These accounts do not have auth attribute and Object.assign does not accept undefined as first argument