### PR TITLE
feat: Extend from cozy configuration

### DIFF
--- a/packages/renovate-config-cozy-konnector/package.json
+++ b/packages/renovate-config-cozy-konnector/package.json
@@ -10,7 +10,12 @@
       ],
       "minor": {
         "automerge": true
-      }
+      },
+      "packageRules": [
+        {
+          "schedule": "before 5am every monday"
+        }
+      ]
     }
   }
 }

--- a/packages/renovate-config-cozy-konnector/package.json
+++ b/packages/renovate-config-cozy-konnector/package.json
@@ -6,22 +6,11 @@
   "renovate-config": {
     "default": {
       "extends": [
-        "config:base"
+        "cozy"
       ],
-      "timezone": "Europe/Paris",
       "minor": {
         "automerge": true
-      },
-      "packageRules": [
-        {
-          "excludePackageNames": [
-            "cozy-konnector-libs",
-            "cozy-app-publish"
-          ],
-          "schedule": "before 5am every monday"
-        }
-      ],
-      "prHourlyLimit": 0
+      }
     }
   }
 }


### PR DESCRIPTION
For reference, here is the cozy config : https://github.com/cozy/cozy-libs/blob/master/packages/renovate-config-cozy/package.json#L5-L23

The man change would be that PRs for non-cozy packages would now be made every day **during non office hours**, whereas at the moment they are only made on monday mornings. Would that be a problem?