### PR TITLE
fix(cozy-konnectors-libs): Help sentry triage by adding fingerprinting

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/sentry.js
+++ b/packages/cozy-konnector-libs/src/helpers/sentry.js
@@ -76,7 +76,7 @@ module.exports.captureExceptionAndDie = function(err) {
   } else {
     try {
       log('info', 'Sending exception to Sentry')
-      Raven.captureException(err, afterCaptureException)
+      Raven.captureException(err, { fingerprint: [err.message || err] }, afterCaptureException)
     } catch (e) {
       log('warn', 'Could not send error to Sentry, exiting...')
       log('warn', e)


### PR DESCRIPTION
A short but quality commit
Should add the error to fingerprint to help sentry to put issues in different categories