### PR TITLE
fix: require replay module only when needed

### DIFF
--- a/packages/cozy-jobs-cli/src/standalone.js
+++ b/packages/cozy-jobs-cli/src/standalone.js
@@ -65,5 +65,6 @@ function initReplay() {
   process.env.REPLAY =
     replayOption || (process.env.REPLAY ? process.env.REPLAY : 'bloody')
 
+  if (process.env.REPLAY !== 'bloody') require('replay')
   require('replay')
 }


### PR DESCRIPTION
This fixes issue https://github.com/konnectors/cozy-konnector-template/issues/177 . It appears that some headers are modified when using the replay module.