### PR TITLE
Make lib loadable in browser

### DIFF
--- a/packages/cozy-logger/src/log-formats.js
+++ b/packages/cozy-logger/src/log-formats.js
@@ -1,9 +1,11 @@
 const chalk = require('chalk')
 const util = require('util')
 const stringify = require('json-stringify-safe')
-util.inspect.defaultOptions.maxArrayLength = null
-util.inspect.defaultOptions.depth = 2
-util.inspect.defaultOptions.colors = true
+if (util && util.inspect && util.inspect.defaultOptions) {
+  util.inspect.defaultOptions.maxArrayLength = null
+  util.inspect.defaultOptions.depth = 2
+  util.inspect.defaultOptions.colors = true
+}
 
 const LOG_LENGTH_LIMIT = 64 * 1024 - 1
 


### PR DESCRIPTION
As dependency of `cozy-doctypes`, we need to load `cozy-logger` in cozy-home,
this PR make it possible.