### PR TITLE
feat: Update account attributes

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -163,7 +163,7 @@ initialized and ready to use.
 <a name="exp_module_cozyClient--module.exports"></a>
 
 ### module.exports ⏏
-This is a [cozy-client-js](https://cozy.github.io/cozy-client-js/) instance already initialized and ready to use.
+[cozy-client-js](https://cozy.github.io/cozy-client-js/) instance already initialized and ready to use.
 
 If you want to access cozy-client-js directly, this method gives you directly an instance of it,
 initialized according to `COZY_URL` and `COZY_CREDENTIALS` environment variable given by cozy-stack
@@ -405,9 +405,9 @@ await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields)
 Provides an handy method to log the user in,
 on HTML form pages. On success, it resolves to a promise with a parsed body.
 
-<a name="exp_module_signin--signin"></a>
+<a name="exp_module_signin--module.exports"></a>
 
-### signin() ⏏
+### module.exports() ⏏
 Provides an handy method to log the user in,
 on HTML form pages. On success, it resolves to a promise with a parsed body.
 
@@ -658,6 +658,7 @@ fetch account information for your connector.
     * [.init()](#BaseKonnector+init) ⇒ <code>Promise</code>
     * [.saveAccountData(data, options)](#BaseKonnector+saveAccountData) ⇒ <code>Promise</code>
     * [.getAccountData()](#BaseKonnector+getAccountData) ⇒ <code>object</code>
+    * [.updateAccountAttributes()](#BaseKonnector+updateAccountAttributes)
     * [.terminate(message)](#BaseKonnector+terminate)
 
 <a name="new_BaseKonnector_new"></a>
@@ -736,6 +737,12 @@ account.
 
 ### baseKonnector.getAccountData() ⇒ <code>object</code>
 Get the data saved by saveAccountData
+
+**Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
+<a name="BaseKonnector+updateAccountAttributes"></a>
+
+### baseKonnector.updateAccountAttributes()
+Update account attributes and cache the account
 
 **Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
 <a name="BaseKonnector+terminate"></a>

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -178,12 +178,7 @@ class BaseKonnector {
     options.merge = options.merge === undefined ? true : options.merge
     const start = options.merge ? Object.assign({}, this.getAccountData()) : {}
     const newData = Object.assign({}, start, data)
-    return cozy.data
-      .updateAttributes('io.cozy.accounts', this.accountId, { data: newData })
-      .then(account => {
-        this._account = account
-        return account.data
-      })
+    return this.updateAccountAttributes({ data: newData }).then(account => account.data)
   }
 
   /**
@@ -193,6 +188,18 @@ class BaseKonnector {
    */
   getAccountData() {
     return new Secret(this._account.data || {})
+  }
+
+
+  /**
+   * Update account attributes and cache the account
+   */
+  updateAccountAttributes(attributes) {
+    return cozy.data.updateAttributes('io.cozy.accounts', this.accountId, attributes)
+      .then(account => {
+        this._account = account
+        return account
+      })
   }
 
   /**

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
@@ -1,0 +1,46 @@
+jest.mock('./cozyclient', () => ({
+  data: {
+    updateAttributes: jest.fn()
+  }
+}))
+
+const client = require('./cozyclient')
+const BaseKonnector = require('./BaseKonnector')
+
+describe('BaseKonnector', () => {
+  let konn
+
+  beforeEach(() => {
+    konn = new BaseKonnector()
+    konn.accountId = 'account-id'
+    client.data.updateAttributes.mockReset()
+  })
+
+  it('should update account attributes and cache the account', async () => {
+    client.data.updateAttributes.mockImplementation((doctype, id, attrs) => new Promise(resolve => {
+      resolve({
+        data: {
+          preexistingData: 'here'
+        },
+        ...attrs
+      })
+    }))
+
+    const newAuth = {
+      login: '12345',
+      password: '6789'
+    }
+    await konn.updateAccountAttributes({
+      auth: newAuth
+    })
+    expect(client.data.updateAttributes).toHaveBeenCalledWith('io.cozy.accounts', 'account-id', {
+      auth: newAuth
+    })
+    expect(konn._account).toMatchObject({
+      data: {
+        preexistingData: 'here',
+      },
+      auth: newAuth
+    })
+  })
+})


### PR DESCRIPTION
I need in banking konnector to remove the authentication data from the `io.cozy.accounts`. I refactored a bit to provide the public `updateAccountAttributes` method on the konnector.