### PR TITLE
feat: (saveFiles) allow function attribute for filename, fileurl, requestOptions, filestream

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -370,13 +370,15 @@ You need the full permission on `io.cozy.files` in your manifest to use this fun
 
 - `files` is an array of `{ fileurl, filename }` :
 
-  + fileurl: The url of the file. This attribute is mandatory or
-    this item will be ignored
+  + fileurl: The url of the file. This attribute is mandatory or this item will be ignored (can be a function returning the value)
+  + filestream: the stream which will be directly passed to cozyClient.files.create (can also be
+  function returning the stream)
+  + requestOptions (object) : The options passed to request to fetch fileurl (can be a function returning the value)
   + filename : The file name of the item written on disk. This attribute is optional and as default value, the
     file name will be "smartly" guessed by the function. Use this attribute if the guess is not smart
-  enough for you.
+  enough for you (can be a function returning the value).
   + `shouldReplaceName` (string) default: `undefined` use to select the old filename to replace
-  by filename if possible
+  by filename if possible (can be a function returning the value)
   + `fileAttributes` (object) ex: `{created_at: new Date()}` sets some additionnal file
   attributes passed to cozyClient.file.create
 

--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -168,6 +168,12 @@ module.exports = {
         } else {
           // file is a string
           fs.writeFileSync(finalPath, file)
+          resolve({
+            _id: options.name,
+            attributes: {
+              name: options.name
+            }
+          })
         }
       })
     },

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -71,7 +71,7 @@ const createFile = async function(entry, options) {
     createFileOptions = { ...createFileOptions, ...entry.fileAttributes }
   }
 
-  const toCreate = entry.filestream || downloadEntry(entry, options)
+  const toCreate = await (entry.filestream || downloadEntry(entry, options))
   let fileDocument = await cozy.files.create(toCreate, createFileOptions)
 
   // This allows us to have the warning message at the first run
@@ -151,13 +151,15 @@ const saveEntry = function(entry, options) {
  *
  * - `files` is an array of `{ fileurl, filename }` :
  *
- *   + fileurl: The url of the file. This attribute is mandatory or
- *     this item will be ignored
+ *   + fileurl: The url of the file. This attribute is mandatory or this item will be ignored (can be a function returning the value)
+ *   + filestream: the stream which will be directly passed to cozyClient.files.create (can also be
+ *   function returning the stream)
+ *   + requestOptions (object) : The options passed to request to fetch fileurl (can be a function returning the value)
  *   + filename : The file name of the item written on disk. This attribute is optional and as default value, the
  *     file name will be "smartly" guessed by the function. Use this attribute if the guess is not smart
- *   enough for you.
+ *   enough for you (can be a function returning the value).
  *   + `shouldReplaceName` (string) default: `undefined` use to select the old filename to replace
- *   by filename if possible
+ *   by filename if possible (can be a function returning the value)
  *   + `fileAttributes` (object) ex: `{created_at: new Date()}` sets some additionnal file
  *   attributes passed to cozyClient.file.create
  *
@@ -218,13 +220,25 @@ const saveFiles = async (entries, fields, options = {}) => {
     await bluebird.map(
       entries,
       async entry => {
+        ;[
+          'fileurl',
+          'filename',
+          'shouldReplaceName',
+          'requestOptions',
+          'filestream'
+        ].forEach(key => {
+          if (entry[key])
+            entry[key] = getValOrFnResult(entry[key], entry, options)
+        })
         if (entry.shouldReplaceName) {
           // At first encounter of a rename, we set the filenamesList
-          if(filesArray === undefined) {
+          if (filesArray === undefined) {
             log('debug', 'initialize files list for renamming')
             filesArray = await getFiles(fields.folderPath)
           }
-          const fileFound = filesArray.find(f => f.name === entry.shouldReplaceName)
+          const fileFound = filesArray.find(
+            f => f.name === entry.shouldReplaceName
+          )
           if (fileFound) {
             await renameFile(fileFound, entry)
             return
@@ -320,13 +334,12 @@ function logFileStream(fileStream) {
     )
   } else {
     log('info', `The fileStream attribute is a ${typeof fileStream}`)
-    // console.log(fileStream)
   }
 }
 
 async function getFiles(folderPath) {
   const dir = await cozy.files.statByPath(folderPath)
-  const files = await queryAll('io.cozy.files', {dir_id: dir._id})
+  const files = await queryAll('io.cozy.files', { dir_id: dir._id })
   return files
 }
 
@@ -335,7 +348,7 @@ async function renameFile(file, entry) {
     throw new Error('shouldReplaceName needs a filename')
   }
   log('debug', `Renaming ${file.name} to ${entry.filename}`)
-  await cozy.files.updateAttributesById(file._id, { name: entry.filename})
+  await cozy.files.updateAttributesById(file._id, { name: entry.filename })
 }
 
 function getErrorStatus(err) {
@@ -344,4 +357,10 @@ function getErrorStatus(err) {
   } catch (e) {
     return null
   }
+}
+
+function getValOrFnResult(val, ...args) {
+  if (typeof val === 'function') {
+    return val.apply(val, args)
+  } else return val
 }


### PR DESCRIPTION
This will allow for example to generate a filestream (essentially a download) only when needed
(if the file does not exist yet)

Can allow more elegant syntaxes