### PR TITLE
feat: add CookieKonnector

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -52,6 +52,15 @@ It takes a fetch function in parameter that must return a <code>Promise</code>.
 You need at least the <code>GET</code> permission on <code>io.cozy.accounts</code> in your manifest to allow it to
 fetch account information for your connector.</p>
 </dd>
+<dt><a href="#CookieKonnector">CookieKonnector</a></dt>
+<dd><p>Connector base class extending BaseKonnector which handles cookie session in a central way
+It also handles saving cookie session in the account and automatically restore it for the next
+connector run.
+All cozy-konnector-libs tools using request are proposed as methods of this class to force them
+to use the central cookie which can be saved/restored.
+You need at least the <code>GET</code> and <code>PUT</code> permissions on <code>io.cozy.accounts</code> in your manifest to allow
+it to save/restore cookies</p>
+</dd>
 <dt><a href="#Document">Document</a></dt>
 <dd><p>Simple Model for Documents. Allows to specify
 <code>shouldSave</code>, <code>shouldUpdate</code> as methods.</p>
@@ -764,6 +773,127 @@ connector now
 | --- | --- | --- |
 | message | <code>string</code> | The error code to be saved as connector result see [docs/ERROR_CODES.md] |
 
+<a name="CookieKonnector"></a>
+
+## CookieKonnector
+Connector base class extending BaseKonnector which handles cookie session in a central way
+It also handles saving cookie session in the account and automatically restore it for the next
+connector run.
+All cozy-konnector-libs tools using request are proposed as methods of this class to force them
+to use the central cookie which can be saved/restored.
+You need at least the `GET` and `PUT` permissions on `io.cozy.accounts` in your manifest to allow
+it to save/restore cookies
+
+**Kind**: global class  
+
+* [CookieKonnector](#CookieKonnector)
+    * [new CookieKonnector(requestFactoryOptions)](#new_CookieKonnector_new)
+    * [.init()](#CookieKonnector+init) ⇒ <code>Promise</code>
+    * [.end()](#CookieKonnector+end)
+    * [.requestFactory(options)](#CookieKonnector+requestFactory) ⇒ <code>object</code>
+    * [.resetSession()](#CookieKonnector+resetSession) ⇒ <code>Promise</code>
+    * [.initSession()](#CookieKonnector+initSession) ⇒ <code>Promise</code>
+    * [.saveSession()](#CookieKonnector+saveSession) ⇒ <code>Promise</code>
+    * [.signin()](#CookieKonnector+signin) ⇒ <code>Promise</code>
+    * [.saveFiles()](#CookieKonnector+saveFiles) ⇒ <code>Promise</code>
+    * [.saveBills()](#CookieKonnector+saveBills) ⇒ <code>Promise</code>
+
+<a name="new_CookieKonnector_new"></a>
+
+### new CookieKonnector(requestFactoryOptions)
+Constructor
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| requestFactoryOptions | <code>function</code> | Option object passed to requestFactory to initialize this.request. It is still possible to change this.request doing : ```javascript this.request = this.requestFactory(...) ``` Please not you have to run the connector yourself doing : ```javascript connector.run() ``` |
+
+**Example**  
+```javascript
+const { CookieKonnector } = require('cozy-konnector-libs')
+class MyConnector extends CookieKonnector {
+  async fetch(fields) {
+     // the code of your connector
+     await this.request('https://...')
+  }
+  async testSession() {
+     const $ = await this.request('https://...')
+     return $('')
+  }
+}
+const connector = new MyKonnector({
+  cheerio: true,
+  json: false
+})
+connector.run()
+```
+<a name="CookieKonnector+init"></a>
+
+### cookieKonnector.init() ⇒ <code>Promise</code>
+Initializes the current connector with data coming from the associated account
+and also the session
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+**Returns**: <code>Promise</code> - with the fields as an object  
+<a name="CookieKonnector+end"></a>
+
+### cookieKonnector.end()
+Hook called when the connector is ended
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+<a name="CookieKonnector+requestFactory"></a>
+
+### cookieKonnector.requestFactory(options) ⇒ <code>object</code>
+Calls cozy-konnector-libs requestFactory forcing this._jar as the cookie
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+**Returns**: <code>object</code> - - The resulting request object  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>object</code> | requestFactory option |
+
+<a name="CookieKonnector+resetSession"></a>
+
+### cookieKonnector.resetSession() ⇒ <code>Promise</code>
+Reset cookie session with a new empty session and save it to the associated account
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+<a name="CookieKonnector+initSession"></a>
+
+### cookieKonnector.initSession() ⇒ <code>Promise</code>
+Get the cookie session from the account if any
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+**Returns**: <code>Promise</code> - true or false if the session in the account exists or not  
+<a name="CookieKonnector+saveSession"></a>
+
+### cookieKonnector.saveSession() ⇒ <code>Promise</code>
+Saves the current cookie session to the account
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+<a name="CookieKonnector+signin"></a>
+
+### cookieKonnector.signin() ⇒ <code>Promise</code>
+This is signin function from cozy-konnector-libs which is forced to use the current cookies
+and current request from CookieKonnector. It also automatically saves the session after
+signin if it is a success.
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+<a name="CookieKonnector+saveFiles"></a>
+
+### cookieKonnector.saveFiles() ⇒ <code>Promise</code>
+This is saveFiles function from cozy-konnector-libs which is forced to use the current cookies
+and current request from CookieKonnector.
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
+<a name="CookieKonnector+saveBills"></a>
+
+### cookieKonnector.saveBills() ⇒ <code>Promise</code>
+This is saveBills function from cozy-konnector-libs which is forced to use the current cookies
+and current request from CookieKonnector.
+
+**Kind**: instance method of [<code>CookieKonnector</code>](#CookieKonnector)  
 <a name="Document"></a>
 
 ## Document

--- a/packages/cozy-konnector-libs/src/index.js
+++ b/packages/cozy-konnector-libs/src/index.js
@@ -6,6 +6,7 @@ require('./libs/error')
 
 module.exports = {
   BaseKonnector: require('./libs/BaseKonnector'),
+  CookieKonnector: require('./libs/CookieKonnector'),
   cozyClient: require('./libs/cozyclient'),
   errors: require('./helpers/errors'),
   log,

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -73,7 +73,7 @@ class BaseKonnector {
         }
         return prom
       })
-      .then(this.end)
+      .then(this.end.bind(this))
       .catch(this.fail.bind(this))
   }
 

--- a/packages/cozy-konnector-libs/src/libs/CookieKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/CookieKonnector.js
@@ -1,0 +1,196 @@
+'use strict'
+
+const log = require('cozy-logger').namespace('CookieKonnector')
+const BaseKonnector = require('./BaseKonnector')
+const requestFactory = require('./request')
+const signin = require('./signin')
+const saveFiles = require('./saveFiles')
+const saveBills = require('./saveBills')
+
+const { CookieJar } = require('tough-cookie')
+const JAR_ACCOUNT_KEY = 'session'
+
+/**
+ * @class
+ * Connector base class extending BaseKonnector which handles cookie session in a central way
+ * It also handles saving cookie session in the account and automatically restore it for the next
+ * connector run.
+ * All cozy-konnector-libs tools using request are proposed as methods of this class to force them
+ * to use the central cookie which can be saved/restored.
+ * You need at least the `GET` and `PUT` permissions on `io.cozy.accounts` in your manifest to allow
+ * it to save/restore cookies
+ *
+ * @example
+ * ```javascript
+ * const { CookieKonnector } = require('cozy-konnector-libs')
+ * class MyConnector extends CookieKonnector {
+ *   async fetch(fields) {
+ *      // the code of your connector
+ *      await this.request('https://...')
+ *   }
+ *   async testSession() {
+ *      const $ = await this.request('https://...')
+ *      return $('')
+ *   }
+ * }
+ * const connector = new MyKonnector({
+ *   cheerio: true,
+ *   json: false
+ * })
+ * connector.run()
+ * ```
+ *
+ */
+class CookieKonnector extends BaseKonnector {
+  /**
+   * Constructor
+   *
+   * @param  {function} requestFactoryOptions    - Option object passed to requestFactory to
+   * initialize this.request. It is still possible to change this.request doing :
+   *
+   * ```javascript
+   * this.request = this.requestFactory(...)
+   * ```
+   *
+   * Please not you have to run the connector yourself doing :
+   *
+   * ```javascript
+   * connector.run()
+   * ```
+   */
+  constructor(requestFactoryOptions) {
+    super()
+    if (!this.testSession) {
+      throw new Error(
+        'Could not find a testSession method. CookieKonnector needs it to test if a session is valid. Please implement it'
+      )
+    }
+    this._jar = requestFactory().jar()
+    this.request = this.requestFactory(requestFactoryOptions)
+  }
+
+  /**
+   * Initializes the current connector with data coming from the associated account
+   * and also the session
+   *
+   * @return {Promise} with the fields as an object
+   */
+  async init() {
+    const fields = await super.init()
+    await this.initSession()
+    return fields
+  }
+
+  /**
+   * Hook called when the connector is ended
+   */
+  async end() {
+    await this.saveSession()
+    return super.end()
+  }
+
+  /**
+   * Calls cozy-konnector-libs requestFactory forcing this._jar as the cookie
+   *
+   * @param  {object} options - requestFactory option
+   * @return {object} - The resulting request object
+   */
+  requestFactory(options) {
+    this._jar = this._jar || requestFactory().jar()
+    return requestFactory({
+      ...options,
+      jar: this._jar
+    })
+  }
+
+  /**
+   * Reset cookie session with a new empty session and save it to the associated account
+   *
+   * @return {Promise}
+   */
+  async resetSession() {
+    log('info', 'Reset cookie session...')
+    this._jar = requestFactory().jar()
+    return this.saveSession()
+  }
+
+  /**
+   * Get the cookie session from the account if any
+   *
+   * @return {Promise} true or false if the session in the account exists or not
+   */
+  async initSession() {
+    try {
+      const accountData = this.getAccountData()
+      let jar = null
+      if (accountData && accountData.auth) {
+        jar = JSON.parse(accountData.auth[JAR_ACCOUNT_KEY])
+      }
+      if (jar) {
+        log('info', 'found saved session, using it...')
+        this._jar._jar = CookieJar.fromJSON(jar, this._jar._jar.store)
+        return true
+      }
+    } catch (err) {
+      log('info', 'Could not parse session')
+    }
+    log('info', 'Found no session')
+    return false
+  }
+
+  /**
+   * Saves the current cookie session to the account
+   *
+   * @return {Promise}
+   */
+  async saveSession() {
+    const accountData = { ...this._account.data, auth: {} }
+    accountData.auth[JAR_ACCOUNT_KEY] = JSON.stringify(this._jar._jar.toJSON())
+    await this.saveAccountData(accountData)
+    log('info', 'saved the session')
+  }
+
+  /**
+   * This is signin function from cozy-konnector-libs which is forced to use the current cookies
+   * and current request from CookieKonnector. It also automatically saves the session after
+   * signin if it is a success.
+   *
+   * @return {Promise}
+   */
+  async signin(options) {
+    const result = await signin({
+      ...options,
+      requestInstance: this.request
+    })
+    await this.saveSession()
+    return result
+  }
+
+  /**
+   * This is saveFiles function from cozy-konnector-libs which is forced to use the current cookies
+   * and current request from CookieKonnector.
+   *
+   * @return {Promise}
+   */
+  saveFiles(entries, fields, options) {
+    return saveFiles(entries, fields, {
+      ...options,
+      requestInstance: this.request
+    })
+  }
+
+  /**
+   * This is saveBills function from cozy-konnector-libs which is forced to use the current cookies
+   * and current request from CookieKonnector.
+   *
+   * @return {Promise}
+   */
+  saveBills(entries, fields, options) {
+    return saveBills(entries, fields, {
+      ...options,
+      requestInstance: this.request
+    })
+  }
+}
+
+module.exports = CookieKonnector


### PR DESCRIPTION
A new new connector class extending BaseKonnector which handle cookies in a central way. It is also able to save the session in the account and restores it in the next connector run