### PR TITLE
fix: shouldReplaceFile

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -197,6 +197,11 @@ module.exports = {
         body: stream,
         buffer: () => rawBody(stream)
       }
+    },
+    trashById(fileId) {
+      const realpath = path.join(rootPath, fileId)
+      fs.unlinkSync(realpath)
+      return Promise.resolve()
     }
   }
 }

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -19,6 +19,7 @@ const DEFAULT_CONCURRENCY = 1
 const sanitizeEntry = function(entry) {
   delete entry.requestOptions
   delete entry.filestream
+  delete entry.shouldReplaceFile
   return entry
 }
 
@@ -136,6 +137,7 @@ const saveEntry = function(entry, options) {
       if (shouldReplaceFile(file, entry, options, filepath)) {
         log('info', `Replacing ${filepath}...`)
         await removeFile(file)
+        throw new Error('REPLACE_FILE')
       }
       return file
     })
@@ -143,7 +145,8 @@ const saveEntry = function(entry, options) {
       file => {
         return file
       },
-      () => {
+      err => {
+        log('info', `${err.message}`)
         log('debug', omit(entry, 'filestream'))
         logFileStream(entry.filestream)
         log('debug', `File ${filepath} does not exist yet or is not valid`)


### PR DESCRIPTION
When a file would be replaced, it was only removed and the file would be download for the next run
of the connector.
Also makes file replacing work in standalone mode.