### PR TITLE
docs(konnector-libs): Add doc for categorization

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -45,6 +45,9 @@ exist in the cozy or not</p>
 <dt><a href="#module_utils">utils</a></dt>
 <dd><p>Small utilities helping to develop konnectors.</p>
 </dd>
+<dt><a href="#module_categorization">categorization</a></dt>
+<dd><p>Bank transactions categorization</p>
+</dd>
 </dl>
 
 ## Classes
@@ -720,6 +723,46 @@ const date = formatFrenchDate(New Date.now())
 ```
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
+<a name="module_categorization"></a>
+
+## categorization
+Bank transactions categorization
+
+<a name="module_categorization..categorize"></a>
+
+### categorization~categorize(transactions) ⇒ <code>Array.&lt;Object&gt;</code>
+Apply both global and local categorization models to an array of transactions.
+
+The global model is a model specific to hosted Cozy instances. It is not available for self-hosted instances. It will just do nothing in that case.
+
+The local model is based on the user manual categorizations.
+
+Each model adds two properties to the transactions:
+  * The global model adds `cozyCategoryId` and `cozyCategoryProba`
+  * The local model adds `localCategoryId` and `localCategoryProba`
+
+In the end, each transaction can have up to four different categories. An application can use these categories to show the most significant for the user. See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bank.md#categories for more informations.
+
+**Kind**: inner method of [<code>categorization</code>](#module_categorization)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - The categorized transactions  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| transactions | <code>Array.&lt;Object&gt;</code> | The transactions to categorize |
+
+**Example**  
+```js
+const { BaseKonnector, categorize } = require('cozy-konnector-libs')
+
+class BankingKonnector extends BaseKonnector {
+  saveTransactions() {
+    const transactions = await this.fetchTransactions()
+    const categorizedTransactions = await categorize(transactions)
+
+    // Save categorizedTransactions
+  }
+}
+```
 <a name="BaseKonnector"></a>
 
 ## BaseKonnector

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -44,7 +44,7 @@
     "transpile": "rm -rf dist/* ; babel src --out-dir dist",
     "prepublishOnly": "yarn run transpile",
     "test": "cross-env LOG_LEVEL=info jest ./src",
-    "docs": "jsdoc2md --template jsdoc2md/README.hbs src/libs/*.js src/helpers/*.js > docs/api.md"
+    "docs": "jsdoc2md --template jsdoc2md/README.hbs src/libs/*.js src/helpers/*.js src/libs/categorization/index.js > docs/api.md"
   },
   "standard": {
     "globals": [

--- a/packages/cozy-konnector-libs/src/libs/categorization/globalModel.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/globalModel.js
@@ -35,7 +35,7 @@ const fetchParameters = async () => {
   }
 }
 
-const globalModel = async (classifierOptions, transactions) => {
+async function globalModel(classifierOptions, transactions) {
   log('info', 'Fetching parameters from the stack')
   let parameters
 

--- a/packages/cozy-konnector-libs/src/libs/categorization/index.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/index.js
@@ -1,8 +1,41 @@
+/**
+ * Bank transactions categorization
+ * @module categorization
+ */
+
 const { tokenizer } = require('./helpers')
 const { globalModel } = require('./globalModel')
 const { localModel } = require('./localModel')
 
-const categorize = async transactions => {
+/**
+ * Apply both global and local categorization models to an array of transactions.
+ *
+ * The global model is a model specific to hosted Cozy instances. It is not available for self-hosted instances. It will just do nothing in that case.
+ *
+ * The local model is based on the user manual categorizations.
+ *
+ * Each model adds two properties to the transactions:
+ *   * The global model adds `cozyCategoryId` and `cozyCategoryProba`
+ *   * The local model adds `localCategoryId` and `localCategoryProba`
+ *
+ * In the end, each transaction can have up to four different categories. An application can use these categories to show the most significant for the user. See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bank.md#categories for more informations.
+ *
+ * @param {Object[]} transactions The transactions to categorize
+ * @return {Object[]} The categorized transactions
+ *
+ * @example
+ * const { BaseKonnector, categorize } = require('cozy-konnector-libs')
+ *
+ * class BankingKonnector extends BaseKonnector {
+ *   saveTransactions() {
+ *     const transactions = await this.fetchTransactions()
+ *     const categorizedTransactions = await categorize(transactions)
+ *
+ *     // Save categorizedTransactions
+ *   }
+ * }
+ */
+async function categorize(transactions) {
   const classifierOptions = { tokenizer }
 
   await Promise.all([


### PR DESCRIPTION
I only added `src/libs/categoriation/index.js` to API doc because other files are internals and should not be used directly by the lib users.