### PR TITLE
fix(konnector-libs): Register the client one time in local model

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel.js
@@ -6,6 +6,8 @@ const maxBy = require('lodash/maxBy')
 const bayes = require('classificator')
 const { getLabelWithTags, tokenizer } = require('./helpers')
 
+BankTransaction.registerClient(cozyClient)
+
 const log = logger.namespace('local-categorization-model')
 
 const ALPHA_MIN = 2
@@ -127,7 +129,6 @@ const createLocalClassifier = (
 
 const createLocalModel = async classifierOptions => {
   log('info', 'Fetching manually categorized transactions')
-  BankTransaction.registerClient(cozyClient)
   const transactionsWithManualCat = await BankTransaction.queryAll({
     manualCategoryId: { $exists: true }
   })


### PR DESCRIPTION
Registering the client inside the `localModel` function could cause some
problems if we need to run the model more than one time. Since
`Document.registerClient` can be run only one time, we run it at the
root of the module, so the client is registered for the whole life of
the module.