### PR TITLE
refactor(konnector-libs): Extract fetchTransactionsWithManualCat

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/categorization/fetchTransactionsWithManualCat.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/fetchTransactionsWithManualCat.js
@@ -1,0 +1,14 @@
+const cozyClient = require('../cozyclient')
+const { BankTransaction } = require('cozy-doctypes')
+
+BankTransaction.registerClient(cozyClient)
+
+async function fetchTransactionsWithManualCat() {
+  const transactionsWithManualCat = await BankTransaction.queryAll({
+    manualCategoryId: { $exists: true }
+  })
+
+  return transactionsWithManualCat
+}
+
+module.exports = fetchTransactionsWithManualCat

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel.js
@@ -1,12 +1,9 @@
-const cozyClient = require('../cozyclient')
 const logger = require('cozy-logger')
-const { BankTransaction } = require('cozy-doctypes')
 const uniq = require('lodash/uniq')
 const maxBy = require('lodash/maxBy')
 const bayes = require('classificator')
 const { getLabelWithTags, tokenizer } = require('./helpers')
-
-BankTransaction.registerClient(cozyClient)
+const fetchTransactionsWithManualCat = require('./fetchTransactionsWithManualCat')
 
 const log = logger.namespace('local-categorization-model')
 
@@ -129,9 +126,7 @@ const createLocalClassifier = (
 
 const createLocalModel = async classifierOptions => {
   log('info', 'Fetching manually categorized transactions')
-  const transactionsWithManualCat = await BankTransaction.queryAll({
-    manualCategoryId: { $exists: true }
-  })
+  const transactionsWithManualCat = await fetchTransactionsWithManualCat()
   log(
     'info',
     `Fetched ${

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel.spec.js
@@ -11,14 +11,13 @@ const {
 } = require('./localModel')
 
 const { tokenizer } = require('./helpers')
-const { BankTransaction } = require('cozy-doctypes')
 
-jest
-  .spyOn(BankTransaction, 'queryAll')
-  .mockResolvedValue([
+jest.mock('./fetchTransactionsWithManualCat', () => () =>
+  Promise.resolve([
     { amount: 3001.71, label: 'AAAA BBBB', manualCategoryId: '200110' },
     { amount: 3001.71, label: 'AAAA BBBB', manualCategoryId: '200110' }
   ])
+)
 
 const transactions = [
   { amount: 3001.71, label: 'AAAA BBBB' },


### PR DESCRIPTION
Extracing this function have two benefits:

* It abstracts the `BankTransaction.queryAll` call
* It becomes more easier to mock: we have tests that need to mock it in banks. Mocking `BankTransaction.queryAll` was hard, and since the usage of `BankTransaction.queryAll` is an implementation detail, that was bad