### PR TITLE
fix: Don't crash if root path can't be created (fix #400)

### DIFF
--- a/packages/cozy-jobs-cli/src/konnector-dev.js
+++ b/packages/cozy-jobs-cli/src/konnector-dev.js
@@ -65,8 +65,14 @@ authenticate({ tokenPath: token, manifestPath: manifest })
   .then(() => {
     const { BaseKonnector, mkdirp } = require('cozy-konnector-libs')
     BaseKonnector.prototype.init = async () => {
-      const rootPath = '/cozy-konnector-dev-root'
-      await mkdirp(rootPath)
+      let rootPath = '/cozy-konnector-dev-root'
+      try {
+        await mkdirp(rootPath)
+      }
+      catch (e) {
+        console.log(`Could not create folder ${rootPath}, using / as base folder.`)
+        rootPath = '/'
+      }
       return {
         ...config.fields,
         folderPath: rootPath


### PR DESCRIPTION
Fixes #400 : connectors who don't have files permission can't be run in dev mode. This PR fixes the problem.