### PR TITLE
feat: only handle 2FA in manual executions

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -238,6 +238,14 @@ class BaseKonnector {
    * ```
    */
   async waitForTwoFaCode(params = {}) {
+    if (process.env.COZY_JOB_MANUAL_EXECUTION !== 'true') {
+      log(
+        'warn',
+        `waitForTwoFaCode: this in not a manual execution. It is not possible to handle 2FA here.`
+      )
+      throw new Error('USER_ACTION_NEEDED.TWOFA_EXPIRED')
+    }
+
     const startTime = Date.now()
     const defaultParams = {
       type: 'email',

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
@@ -26,6 +26,7 @@ describe('BaseKonnector', () => {
       asyncResolve({ twofa_code: 'expected code' })
     )
     client.data.updateAttributes.mockReturnValue(asyncResolve({}))
+    process.env.COZY_JOB_MANUAL_EXECUTION = 'true'
     const code = await konn.waitForTwoFaCode({ heartBeat: 100 })
     expect(code).toEqual('expected code')
     expect(client.data.find).toHaveBeenCalled()


### PR DESCRIPTION
We do not try to expect a 2FA code from the user when in automatic execution start by a trigger