### PR TITLE
feat: define Cozymetadata handling in lower level functions like updateOrCreate or addData

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -31,7 +31,8 @@ to an existing bank operation</p>
 <dd><p>Saves the given files in the given folder via the Cozy API.</p>
 </dd>
 <dt><a href="#module_saveIdentity">saveIdentity</a></dt>
-<dd><p>Helper to set or merge identities</p>
+<dd><p>Helper to set or merge io.cozy.identities
+See <a href="https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.identities.md">https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.identities.md</a></p>
 </dd>
 <dt><a href="#module_signin">signin</a></dt>
 <dd><p>Provides an handy method to log the user in,
@@ -457,7 +458,8 @@ await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields)
 <a name="module_saveIdentity"></a>
 
 ## saveIdentity
-Helper to set or merge identities
+Helper to set or merge io.cozy.identities
+See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.identities.md
 
 <a name="exp_module_saveIdentity--module.exports"></a>
 
@@ -471,6 +473,10 @@ Parameters:
 
 * `contact` (object): the identity to create/update as an object io.cozy.contacts
 * `accountIdentifier` (string): a string that represent the account use, if available fields.login
+* `options` (object): options which will be given to updateOrCreate directly :
+  + `sourceAccount` (String): id of the source account
+  + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
+
 
 ```javascript
 const { saveIdentity } = require('cozy-konnector-libs')
@@ -607,21 +613,21 @@ exist in the cozy or not
 
 <a name="exp_module_updateOrCreate--module.exports"></a>
 
-### module.exports(entries, doctype, matchingAttributes) ⇒ <code>Promise</code> ⏏
+### module.exports() ⏏
 Creates or updates the given entries according to if they already
 exist in the cozy or not
 
 You need the full permission for the given doctype in your manifest, to be able to
 use this function.
 
+* `entries` (object array): Documents to save
+* `doctype` (string): Doctype of the documents
+* `matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
+* `options` (object): general option affecting metadata :
+  + `sourceAccount` (String): id of the source account
+  + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
+
 **Kind**: Exported function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| entries | <code>Array.&lt;Object&gt;</code> | Documents to save |
-| doctype | <code>String</code> | Doctype of the documents |
-| matchingAttributes | <code>Array.&lt;String&gt;</code> | attributes in each entry used to check if an entry already exists in the Cozy |
-
 <a name="module_utils"></a>
 
 ## utils
@@ -864,6 +870,8 @@ fetch account information for your connector.
     * [.updateAccountAttributes()](#BaseKonnector+updateAccountAttributes)
     * [.waitForTwoFaCode()](#BaseKonnector+waitForTwoFaCode)
     * [.saveBills()](#BaseKonnector+saveBills) ⇒ <code>Promise</code>
+    * [.updateOrCreate()](#BaseKonnector+updateOrCreate) ⇒ <code>Promise</code>
+    * [.saveIdentity()](#BaseKonnector+saveIdentity) ⇒ <code>Promise</code>
     * [.terminate(message)](#BaseKonnector+terminate)
     * [.getCozyMetadata(data)](#BaseKonnector+getCozyMetadata)
 
@@ -989,6 +997,20 @@ async function start() {
 
 ### baseKonnector.saveBills() ⇒ <code>Promise</code>
 This is saveBills function from cozy-konnector-libs which automatically adds sourceAccount in
+metadata of each entry
+
+**Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
+<a name="BaseKonnector+updateOrCreate"></a>
+
+### baseKonnector.updateOrCreate() ⇒ <code>Promise</code>
+This is updateOrCreate function from cozy-konnector-libs which automatically adds sourceAccount in
+metadata of each entry
+
+**Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
+<a name="BaseKonnector+saveIdentity"></a>
+
+### baseKonnector.saveIdentity() ⇒ <code>Promise</code>
+This is saveIdentity function from cozy-konnector-libs which automatically adds sourceAccount in
 metadata of each entry
 
 **Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -6,6 +6,9 @@ const { Secret } = require('cozy-logger')
 const manifest = require('./manifest')
 const errors = require('../helpers/errors')
 const saveBills = require('./saveBills')
+const get = require('lodash/get')
+const updateOrCreate = require('./updateOrCreate')
+const saveIdentity = require('./saveIdentity')
 const {
   wrapIfSentrySetUp,
   captureExceptionAndDie
@@ -292,6 +295,34 @@ class BaseKonnector {
     return saveBills(entries, fields, {
       sourceAccount: this.accountId,
       sourceAccountIdentifier: fields.login,
+      ...options
+    })
+  }
+
+  /**
+   * This is updateOrCreate function from cozy-konnector-libs which automatically adds sourceAccount in
+   * metadata of each entry
+   *
+   * @return {Promise}
+   */
+  updateOrCreate(entries, doctype, matchingAttributes, options) {
+    return updateOrCreate(entries, doctype, matchingAttributes, {
+      sourceAccount: this.accountId,
+      sourceAccountIdentifier: get(options, 'fields.login'),
+      ...options
+    })
+  }
+
+  /**
+   * This is saveIdentity function from cozy-konnector-libs which automatically adds sourceAccount in
+   * metadata of each entry
+   *
+   * @return {Promise}
+   */
+  saveIdentity(contact, accountIdentifier, options = {}) {
+    return saveIdentity(contact, accountIdentifier, {
+      sourceAccount: this.accountId,
+      sourceAccountIdentifier: accountIdentifier,
       ...options
     })
   }

--- a/packages/cozy-konnector-libs/src/libs/saveIdentity.js
+++ b/packages/cozy-konnector-libs/src/libs/saveIdentity.js
@@ -7,7 +7,6 @@
 
 const log = require('cozy-logger').namespace('saveIdentity')
 const updateOrCreate = require('./updateOrCreate')
-const { getCozyMetadata } = require('./manifest')
 
 /**
  * Set or merge a io.cozy.identities
@@ -19,6 +18,10 @@ const { getCozyMetadata } = require('./manifest')
  *
  * * `contact` (object): the identity to create/update as an object io.cozy.contacts
  * * `accountIdentifier` (string): a string that represent the account use, if available fields.login
+ * * `options` (object): options which will be given to updateOrCreate directly :
+ *   + `sourceAccount` (String): id of the source account
+ *   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
+ *
  *
  * ```javascript
  * const { saveIdentity } = require('cozy-konnector-libs')
@@ -34,7 +37,7 @@ const { getCozyMetadata } = require('./manifest')
  * @alias module:saveIdentity
  */
 
-module.exports = async (contact, accountIdentifier) => {
+module.exports = async (contact, accountIdentifier, options = {}) => {
   if (accountIdentifier == null) {
     log('warn', "Can't set identity as no accountIdentifier was provided")
     return
@@ -55,14 +58,15 @@ module.exports = async (contact, accountIdentifier) => {
 
   const identity = {
     identifier: accountIdentifier,
-    contact: contact,
-    cozyMetadata: getCozyMetadata()
+    contact
   }
 
-  await updateOrCreate([identity], 'io.cozy.identities', [
-    'identifier',
-    'cozyMetadata.createdByApp'
-  ])
+  await updateOrCreate(
+    [identity],
+    'io.cozy.identities',
+    ['identifier', 'cozyMetadata.createdByApp'],
+    options
+  )
   return
 }
 

--- a/packages/cozy-konnector-libs/src/libs/updateOrCreate.js
+++ b/packages/cozy-konnector-libs/src/libs/updateOrCreate.js
@@ -8,6 +8,7 @@ const bluebird = require('bluebird')
 const log = require('cozy-logger').namespace('updateOrCreate')
 const cozy = require('./cozyclient')
 const get = require('lodash/get')
+const { getCozyMetadata } = require('./manifest')
 
 /**
  * Creates or updates the given entries according to if they already
@@ -16,33 +17,48 @@ const get = require('lodash/get')
  * You need the full permission for the given doctype in your manifest, to be able to
  * use this function.
  *
- * @param  {Object[]}  entries - Documents to save
- * @param  {String} doctype - Doctype of the documents
- * @param  {String[]}  matchingAttributes - attributes in each entry used to check if an entry already exists in the Cozy
- * @return {Promise}
+ * * `entries` (object array): Documents to save
+ * * `doctype` (string): Doctype of the documents
+ * * `matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
+ * * `options` (object): general option affecting metadata :
+ *   + `sourceAccount` (String): id of the source account
+ *   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
  *
  * @alias module:updateOrCreate
  */
-module.exports = (entries = [], doctype, matchingAttributes = []) => {
+module.exports = (
+  entries = [],
+  doctype,
+  matchingAttributes = [],
+  options = {}
+) => {
   return cozy.data.findAll(doctype).then(existings =>
     bluebird.mapSeries(entries, entry => {
       log('debug', entry)
+      const metaEntry = {
+        cozyMetadata: getCozyMetadata({
+          ...entry.cozyMetadata,
+          sourceAccount: options.sourceAccount,
+          sourceAccountIdentifier: options.sourceAccountIdentifier
+        }),
+        ...entry
+      }
       // try to find a corresponding existing element
       const toUpdate = existings.find(doc =>
         matchingAttributes.reduce(
           (isMatching, matchingAttribute) =>
             isMatching &&
-            get(doc, matchingAttribute) === get(entry, matchingAttribute),
+            get(doc, matchingAttribute) === get(metaEntry, matchingAttribute),
           true
         )
       )
 
       if (toUpdate) {
         log('debug', 'updating')
-        return cozy.data.updateAttributes(doctype, toUpdate._id, entry)
+        return cozy.data.updateAttributes(doctype, toUpdate._id, metaEntry)
       } else {
         log('debug', 'creating')
-        return cozy.data.create(doctype, entry)
+        return cozy.data.create(doctype, metaEntry)
       }
     })
   )


### PR DESCRIPTION
Higher level function like saveBills or saveIdentity do not need to know about Cozymetadata most of the time