### PR TITLE
feat (saveBills): add matchingCriterias handling to saveBills

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -376,6 +376,9 @@ Parameters:
   + `vendor` (String): the name of the vendor associated to the bill. Ex: 'trainline'
   + `currency` (String) default: EUR:  The ISO currency value (not mandatory since there is a
   default value.
+  + `matchingCriterias` (Object): criterias that can be used by an external service to match bills
+  with bank operations. If not specified but the 'banksTransactionRegExp' attribute is specified in the
+  manifest of the connector, this value is automatically added to the bill
 
   You can also pass attributes expected by `saveFiles` : fileurl, filename, requestOptions
   and more

--- a/packages/cozy-konnector-libs/src/libs/saveBills.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveBills.spec.js
@@ -1,0 +1,78 @@
+jest.mock('./saveFiles')
+jest.mock('./hydrateAndFilter')
+jest.mock('./addData')
+const addData = require('./addData')
+const hydrateAndFilter = require('./hydrateAndFilter')
+const saveFiles = require('./saveFiles')
+const saveBills = require('./saveBills')
+const manifest = require('./manifest')
+const logger = require('cozy-logger')
+const asyncResolve = val => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(val)
+    }, 1)
+  })
+}
+
+logger.setLevel('critical')
+
+beforeEach(async function() {
+  saveFiles.mockImplementation(entries => {
+    return asyncResolve(entries.map(doc => ({ ...doc, fileDocument: true })))
+  })
+  hydrateAndFilter.mockImplementation(entries => {
+    return asyncResolve(entries)
+  })
+  addData.mockImplementation(entries => {
+    return asyncResolve(entries)
+  })
+})
+
+describe('saveBills', function() {
+  it('should check required attributes in bills', async () => {
+    expect.assertions(1)
+    try {
+      await saveBills(
+        [
+          {
+            filename: 'filename',
+            fileurl: 'fileurl',
+            amount: 'bad amount type',
+            date: new Date(),
+            vendor: 'vendor'
+          }
+        ],
+        {
+          linkBankOperations: false
+        }
+      )
+    } catch (err) {
+      expect(err.message).toEqual(
+        'saveBills: an entry has a amount which does not respect isNumber'
+      )
+    }
+  })
+  it('should add label transaction regexp if found in the manifest', async () => {
+    manifest.data = { banksTransactionRegExp: 'toto regexp' }
+    const entry = {
+      filename: 'filename',
+      fileurl: 'fileurl',
+      amount: 12,
+      date: new Date(),
+      vendor: 'vendor'
+    }
+    const result = await saveBills([entry], null, {
+      linkBankOperations: false
+    })
+
+    expect(result).toEqual([
+      {
+        ...entry,
+        matchingCriterias: { labelRegex: 'toto regexp' },
+        currency: 'EUR',
+        invoice: 'io.cozy.files:undefined'
+      }
+    ])
+  })
+})


### PR DESCRIPTION
- if specified as an attribute of bills, this attribute is recorded
- else, if the manifest of the connector has any 'banksTransactionRegExp' attribute, add
  this attribute as `matchingCriterias.labelRegex` to the bill
- existing bills will be updated with matchingCriterias if any
- else do nothing

The different possible matchingCriterias as documented in https://github.com/cozy/cozy-doctypes/pull/103