### PR TITLE
feat: init a new cozy-client instance and make it available in cozy-konnector-libs

### DIFF
--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -36,7 +36,6 @@
     "pdfjs-dist": "2.1.266",
     "raven": "2.6.4",
     "raw-body": "2.4.1",
-    "react": "16.8.6",
     "request": "2.88.0",
     "request-debug": "0.2.0",
     "request-promise": "4.2.4",

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -22,7 +22,7 @@
     "bluebird-retry": "0.11.0",
     "cheerio": "1.0.0-rc.3",
     "classificator": "0.3.3",
-    "cozy-client": "6.55.1",
+    "cozy-client": "6.57.0",
     "cozy-client-js": "0.16.4",
     "cozy-doctypes": "1.58.0",
     "cozy-logger": "1.3.1",
@@ -82,7 +82,8 @@
     "express": "4.17.1",
     "jest": "24.8.0",
     "jsdoc-to-markdown": "4.0.1",
-    "lerna": "3.16.4"
+    "lerna": "3.16.4",
+    "react": "16.9.0"
   },
   "prettier": {
     "semi": false,

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -8,6 +8,7 @@
 /* eslint no-console: off */
 
 const { Client, MemoryStorage } = require('cozy-client-js')
+const NewCozyClient = require('cozy-client/dist/CozyClient').default
 
 const getCredentials = function(environment) {
   try {
@@ -62,6 +63,11 @@ const getCozyClient = function(environment = 'production') {
   if (environment === 'development') {
     cozyClient.saveCredentials(credentials.client, credentials.token)
   }
+
+  cozyClient.new = new NewCozyClient({
+    uri: cozyClient._uri,
+    token: cozyClient._token
+  })
 
   return cozyClient
 }

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -9,6 +9,7 @@
 
 const { Client, MemoryStorage } = require('cozy-client-js')
 const NewCozyClient = require('cozy-client/dist/CozyClient').default
+const manifest = require('./manifest')
 
 const getCredentials = function(environment) {
   try {
@@ -64,9 +65,15 @@ const getCozyClient = function(environment = 'production') {
     cozyClient.saveCredentials(credentials.client, credentials.token)
   }
 
+  const cozyFields = JSON.parse(process.env.COZY_FIELDS || '{}')
   cozyClient.new = new NewCozyClient({
     uri: cozyClient._uri,
-    token: cozyClient._token
+    token: cozyClient._token,
+    appMetadata: {
+      slug: manifest.data.slug,
+      sourceAccount: cozyFields.account,
+      version: manifest.data.version
+    }
   })
 
   return cozyClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -7624,16 +7624,6 @@ react-redux@5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
-react@16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
-
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
@@ -8134,14 +8124,6 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^0.4.0:
   version "0.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,13 +2969,13 @@ cozy-client-js@0.16.4:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@6.55.1:
-  version "6.55.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.55.1.tgz#4f07d1bc71de086e7c6761c27be31bf093dbc939"
-  integrity sha512-wjJQGQ+ZMDrXeY366+EH5UY2VbW/24DODEYovg6MjSlwXJQduZOfWNjvITH+29g7IQiN6CXhZ/q61Vuph60WEg==
+cozy-client@6.57.0:
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.57.0.tgz#96b72ab00ce28c1bfe0e5fcf8ff32d78dbb1dbb9"
+  integrity sha512-QF+TJ9sp6RrIURFB9yJMP4b6ifX+7qapfy/Hlj+ThZJAQoLIoe3DaGri2MBYNqbkSYXvUlmG50HFa1NC3/5OZA==
   dependencies:
     cozy-device-helper "1.7.3"
-    cozy-stack-client "^6.55.0"
+    cozy-stack-client "^6.57.0"
     lodash "4.17.14"
     microee "0.0.6"
     prop-types "15.6.2"
@@ -3018,10 +3018,10 @@ cozy-logger@1.5.0, cozy-logger@^1.5.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^6.55.0:
-  version "6.55.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.55.0.tgz#8d77e377a6515180b19d5386078845f9ddd7609a"
-  integrity sha512-Ho611ECKLSROrmQ+gLetniU9C5nYP0vIjfMzhRGDWdHkDVrhM19dTjyNoSj9uNd64SrdNs182f8pi183g7TOfQ==
+cozy-stack-client@^6.57.0:
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.57.0.tgz#dc14a795ae403247e232c60d143ab199a123ff18"
+  integrity sha512-mFELDIAd6Yb11inB0ZjBVd8xCQy1euPWf6qHi5A9qs2HMFmK4fkQgIQq2brZOqxfaCmBq/I1jP3OppKcM83K+A==
   dependencies:
     detect-node "2.0.4"
     mime "2.4.0"
@@ -7623,6 +7623,15 @@ react-redux@5.0.7:
     lodash-es "^4.17.5"
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
+
+react@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
To get it :

```javascript
const cozyClient = require('cozy-konnector-libs').cozyClient.new
```

This cozy-client instance is, at the moment, not usable in standalone mode since it is not yet
mocked.