### PR TITLE
feat: add metadata deduplication

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -452,7 +452,7 @@ You need the full permission on `io.cozy.files` in your manifest to use this fun
   + `validateFile` (function) default: do not validate if file is empty or has bad mime type
   + `validateFileContent` (boolean or function) default false. Also check the content of the file to
   recognize the mime type
-  + `filePrimaryKeys` (array of strings). Describe which attributes of files will be taken as primary key for
+  + `fileIdAttributes` (array of strings). Describes which attributes of files will be taken as primary key for
   files to check if they already exist, even if they are moved. If not given, the file path will
   used for deduplication as before.
 
@@ -460,7 +460,7 @@ You need the full permission on `io.cozy.files` in your manifest to use this fun
 **Example**  
 ```javascript
 await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields, {
-   filePrimaryKeys: ['fileurl']
+   fileIdAttributes: ['fileurl']
 })
 ```
 <a name="module_saveIdentity"></a>

--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -412,7 +412,7 @@ Saves the files given in the fileurl attribute of each entries
 
 You need the full permission on `io.cozy.files` in your manifest to use this function.
 
-- `files` is an array of object with the following possible attributes :
+- `files` is an array of objects with the following possible attributes :
 
   + fileurl: The url of the file (can be a function returning the value). Ignored if `filestream`
   is given
@@ -452,11 +452,16 @@ You need the full permission on `io.cozy.files` in your manifest to use this fun
   + `validateFile` (function) default: do not validate if file is empty or has bad mime type
   + `validateFileContent` (boolean or function) default false. Also check the content of the file to
   recognize the mime type
+  + `filePrimaryKeys` (array). Describe which attributes of files will be taken as primary key for
+  files to check if they already exist, even if they are moved. If not given, the file path will
+  used for deduplication as before.
 
 **Kind**: Exported function  
 **Example**  
 ```javascript
-await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields)
+await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields, {
+   filePrimaryKeys: ['fileurl']
+})
 ```
 <a name="module_saveIdentity"></a>
 

--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -452,7 +452,7 @@ You need the full permission on `io.cozy.files` in your manifest to use this fun
   + `validateFile` (function) default: do not validate if file is empty or has bad mime type
   + `validateFileContent` (boolean or function) default false. Also check the content of the file to
   recognize the mime type
-  + `filePrimaryKeys` (array). Describe which attributes of files will be taken as primary key for
+  + `filePrimaryKeys` (array of strings). Describe which attributes of files will be taken as primary key for
   files to check if they already exist, even if they are moved. If not given, the file path will
   used for deduplication as before.
 

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -20,361 +20,6 @@ const fileType = require('file-type')
 const DEFAULT_TIMEOUT = Date.now() + 4 * 60 * 1000 // 4 minutes by default since the stack allows 5 minutes
 const DEFAULT_CONCURRENCY = 1
 const DEFAULT_RETRY = 1 // do not retry by default
-const DEFAULT_VALIDATE_FILE = fileDocument =>
-  checkFileSize(fileDocument) && checkMimeWithPath(fileDocument)
-const DEFAULT_VALIDATE_FILECONTENT = async fileDocument => {
-  const response = await cozy.files.downloadById(fileDocument._id)
-  const mime = get(fileDocument, 'attributes.mime', fileDocument.mime)
-  const fileTypeFromContent = fileType(await response.buffer())
-  if (!fileTypeFromContent) {
-    log('warn', `Could not find mime type from file content`)
-    return false
-  }
-
-  if (
-    !DEFAULT_VALIDATE_FILE(fileDocument) ||
-    mime !== fileTypeFromContent.mime
-  ) {
-    log(
-      'warn',
-      `Wrong file type from content ${JSON.stringify(fileTypeFromContent)}`
-    )
-    return false
-  }
-  return true
-}
-
-const sanitizeEntry = function(entry) {
-  delete entry.requestOptions
-  delete entry.filestream
-  delete entry.shouldReplaceFile
-  return entry
-}
-
-function getRequestInstance(entry, options) {
-  return options.requestInstance
-    ? options.requestInstance
-    : requestFactory({
-        json: false,
-        cheerio: false,
-        userAgent: true,
-        jar: true
-      })
-}
-
-function getRequestOptions(entry, options) {
-  const defaultRequestOptions = {
-    uri: entry.fileurl,
-    method: 'GET'
-  }
-
-  if (!options.requestInstance) {
-    // if requestInstance is already set, we suppose that the connecteur want to handle the cookie
-    // jar itself
-    defaultRequestOptions.jar = true
-  }
-
-  return {
-    ...defaultRequestOptions,
-    ...entry.requestOptions
-  }
-}
-
-const downloadEntry = function(entry, options) {
-  let filePromise = getRequestInstance(entry, options)(
-    getRequestOptions(entry, options)
-  )
-
-  if (options.contentType) {
-    // the developper wants to foce the contentType of the document
-    // we pipe the stream to remove headers with bad contentType from the request
-    return filePromise.pipe(new stream.PassThrough())
-  }
-
-  // we have to do this since the result of filePromise is not a stream and cannot be taken by
-  // cozy.files.create
-  if (options.postProcessFile) {
-    log(
-      'warn',
-      'Be carefull postProcessFile option is deprecated. You should use the filestream attribute in each entry instead'
-    )
-    return filePromise.then(data => options.postProcessFile(data))
-  }
-  filePromise.catch(err => {
-    log('warn', `File download error ${err.message}`)
-  })
-  return filePromise
-}
-
-const createFile = async function(entry, options, method, fileId) {
-  const folder = await cozy.files.statByPath(options.folderPath)
-  let createFileOptions = {
-    name: getFileName(entry),
-    dirID: folder._id
-  }
-  if (options.contentType) {
-    if (options.contentType === true && entry.filename) {
-      createFileOptions.contentType = mimetypes.contentType(entry.filename)
-    } else {
-      createFileOptions.contentType = options.contentType
-    }
-  }
-  createFileOptions = {
-    ...createFileOptions,
-    ...entry.fileAttributes,
-    ...options.sourceAccountOptions
-  }
-
-  if (options.filePrimaryKeys) {
-    createFileOptions = {
-      ...createFileOptions,
-      ...{
-        metadata: {
-          filePrimaryKeys: calculateFileKey(entry, options.filePrimaryKeys)
-        }
-      }
-    }
-  }
-
-  const toCreate =
-    entry.filestream || downloadEntry(entry, { ...options, simple: false })
-  let fileDocument
-  if (method === 'create') {
-    fileDocument = await cozy.files.create(toCreate, createFileOptions)
-  } else if (method === 'updateById') {
-    log('info', `replacing file for ${entry.filename}`)
-    fileDocument = await cozy.files.updateById(
-      fileId,
-      toCreate,
-      createFileOptions
-    )
-  }
-
-  if (options.validateFile) {
-    if ((await options.validateFile(fileDocument)) === false) {
-      await removeFile(fileDocument)
-      throw new Error('BAD_DOWNLOADED_FILE')
-    }
-
-    if (
-      options.validateFileContent &&
-      !(await options.validateFileContent(fileDocument))
-    ) {
-      await removeFile(fileDocument)
-      throw new Error('BAD_DOWNLOADED_FILE')
-    }
-  }
-
-  return fileDocument
-}
-
-const attachFileToEntry = function(entry, fileDocument) {
-  entry.fileDocument = fileDocument
-  return entry
-}
-
-function getFilePath({ file, entry, options }) {
-  const folderPath = options.folderPath
-  if (file) {
-    return path.join(folderPath, get(file, 'attributes.name', file.name))
-  } else if (entry) {
-    return path.join(folderPath, getFileName(entry))
-  }
-}
-
-const shouldReplaceFile = async function(file, entry, options) {
-  const isValid = !options.validateFile || (await options.validateFile(file))
-  if (!isValid) {
-    log(
-      'warn',
-      `${getFileName({
-        file,
-        options
-      })} is invalid. Downloading it one more time`
-    )
-    throw new Error('BAD_DOWNLOADED_FILE')
-  }
-  const defaultShouldReplaceFile = (file, entry) => {
-    // replace all files with meta if there is file metadata to add
-    const fileHasNoMetadata = !get(file, 'attributes.metadata', file.metadata)
-    const entryHasMetadata = !!get(entry, 'fileAttributes.metadata')
-    return fileHasNoMetadata && (entryHasMetadata || options.filePrimaryKeys)
-  }
-  const shouldReplaceFileFn =
-    entry.shouldReplaceFile ||
-    options.shouldReplaceFile ||
-    defaultShouldReplaceFile
-
-  return shouldReplaceFileFn(file, entry)
-}
-
-const removeFile = async function(file) {
-  await cozy.files.trashById(file._id)
-  await cozy.files.destroyById(file._id)
-}
-
-async function getFileIfExists(entry, options) {
-  const filePrimaryKeys = options.filePrimaryKeys
-  if (!filePrimaryKeys) {
-    log(
-      'warn',
-      `saveFiles: no deduplication key is defined, file deduplication will be based on file path`
-    )
-  }
-
-  const slug = manifest.data.slug
-  if (!slug) {
-    log(
-      'warn',
-      `saveFiles: no slug is defined for the current connector, file deduplication will be based on file path`
-    )
-  }
-
-  const sourceAccountIdentifier = get(
-    options,
-    'sourceAccountOptions.sourceAccountIdentifier'
-  )
-  if (!sourceAccountIdentifier) {
-    log(
-      'warn',
-      `saveFiles: no sourceAccountIdentifier is defined in options, file deduplication will be based on file path`
-    )
-  }
-
-  if (!filePrimaryKeys || !slug || !sourceAccountIdentifier) {
-    try {
-      const result = await cozy.files.statByPath(
-        getFilePath({ entry, options })
-      )
-      return result
-    } catch (err) {
-      log('debug', err.message)
-      return false
-    }
-  } else {
-    const index = await cozy.data.defineIndex('io.cozy.files', [
-      'metadata.filePrimaryKeys',
-      'trashed',
-      'cozyMetadata.sourceAccountIdentifier',
-      'cozyMetadata.createdByApp'
-    ])
-    const files = await queryAll(
-      'io.cozy.files',
-      {
-        metadata: {
-          filePrimaryKeys: calculateFileKey(entry, filePrimaryKeys)
-        },
-        trashed: false,
-        cozyMetadata: {
-          sourceAccountIdentifier: sourceAccountIdentifier,
-          createdByApp: slug
-        }
-      },
-      index
-    )
-    if (files && files[0]) {
-      if (files.length > 1) {
-        log(
-          'warn',
-          `Found ${files.length} files corresponding to ${calculateFileKey(
-            entry,
-            filePrimaryKeys
-          )}`
-        )
-      }
-      return files[0]
-    } else {
-      try {
-        const result = await cozy.files.statByPath(
-          getFilePath({ entry, options })
-        )
-        return result
-      } catch (err) {
-        log('debug', err.message)
-        return false
-      }
-    }
-  }
-}
-
-const saveEntry = async function(entry, options) {
-  if (options.timeout && Date.now() > options.timeout) {
-    const remainingTime = Math.floor((options.timeout - Date.now()) / 1000)
-    log('info', `${remainingTime}s timeout finished for ${options.folderPath}`)
-    throw new Error('TIMEOUT')
-  }
-
-  let file = await getFileIfExists(entry, options)
-  let shouldReplace = false
-  if (file) {
-    try {
-      shouldReplace = await shouldReplaceFile(file, entry, options)
-    } catch (err) {
-      log('info', `Error in shouldReplace : ${err.message}`)
-      shouldReplace = true
-    }
-  }
-
-  let method = 'create'
-
-  if (shouldReplace && file) {
-    method = 'updateById'
-    log('info', `Will replace ${getFilePath({ options, file })}...`)
-  }
-
-  try {
-    if (!file || method === 'updateById') {
-      log('debug', omit(entry, 'filestream'))
-      logFileStream(entry.filestream)
-      log(
-        'debug',
-        `File ${getFilePath({
-          options,
-          entry
-        })} does not exist yet or is not valid`
-      )
-      entry._cozy_file_to_create = true
-      file = await retry(createFile, {
-        interval: 1000,
-        throw_original: true,
-        max_tries: options.retry,
-        args: [entry, options, method, file ? file._id : undefined]
-      }).catch(err => {
-        if (err.message === 'BAD_DOWNLOADED_FILE') {
-          log(
-            'warn',
-            `Could not download file after ${
-              options.retry
-            } tries removing the file`
-          )
-        } else {
-          log('warn', 'unknown file download error: ' + err.message)
-        }
-      })
-    }
-
-    attachFileToEntry(entry, file)
-
-    sanitizeEntry(entry)
-    if (options.postProcess) {
-      await options.postProcess(entry)
-    }
-  } catch (err) {
-    if (getErrorStatus(err) === 413) {
-      // the cozy quota is full
-      throw new Error(errors.DISK_QUOTA_EXCEEDED)
-    }
-    log('warn', errors.SAVE_FILE_FAILED)
-    log(
-      'warn',
-      err.message,
-      `Error caught while trying to save the file ${
-        entry.fileurl ? entry.fileurl : entry.filename
-      }`
-    )
-  }
-  return entry
-}
 
 /**
  * Saves the files given in the fileurl attribute of each entries
@@ -464,7 +109,7 @@ const saveFiles = async (entries, fields, options = {}) => {
     contentType: options.contentType,
     requestInstance: options.requestInstance,
     shouldReplaceFile: options.shouldReplaceFile,
-    validateFile: options.validateFile || DEFAULT_VALIDATE_FILE,
+    validateFile: options.validateFile || defaultValidateFile,
     sourceAccountOptions: {
       sourceAccount: options.sourceAccount,
       sourceAccountIdentifier: options.sourceAccountIdentifier
@@ -473,7 +118,7 @@ const saveFiles = async (entries, fields, options = {}) => {
 
   if (options.validateFileContent) {
     if (options.validateFileContent === true) {
-      saveOptions.validateFileContent = DEFAULT_VALIDATE_FILECONTENT
+      saveOptions.validateFileContent = defaultValidateFileContent
     } else if (typeof options.validateFileContent === 'function') {
       saveOptions.validateFileContent = options.validateFileContent
     }
@@ -557,6 +202,288 @@ const saveFiles = async (entries, fields, options = {}) => {
   return savedEntries
 }
 
+const saveEntry = async function(entry, options) {
+  if (options.timeout && Date.now() > options.timeout) {
+    const remainingTime = Math.floor((options.timeout - Date.now()) / 1000)
+    log('info', `${remainingTime}s timeout finished for ${options.folderPath}`)
+    throw new Error('TIMEOUT')
+  }
+
+  let file = await getFileIfExists(entry, options)
+  let shouldReplace = false
+  if (file) {
+    try {
+      shouldReplace = await shouldReplaceFile(file, entry, options)
+    } catch (err) {
+      log('info', `Error in shouldReplace : ${err.message}`)
+      shouldReplace = true
+    }
+  }
+
+  let method = 'create'
+
+  if (shouldReplace && file) {
+    method = 'updateById'
+    log('info', `Will replace ${getFilePath({ options, file })}...`)
+  }
+
+  try {
+    if (!file || method === 'updateById') {
+      log('debug', omit(entry, 'filestream'))
+      logFileStream(entry.filestream)
+      log(
+        'debug',
+        `File ${getFilePath({
+          options,
+          entry
+        })} does not exist yet or is not valid`
+      )
+      entry._cozy_file_to_create = true
+      file = await retry(createFile, {
+        interval: 1000,
+        throw_original: true,
+        max_tries: options.retry,
+        args: [entry, options, method, file ? file._id : undefined]
+      }).catch(err => {
+        if (err.message === 'BAD_DOWNLOADED_FILE') {
+          log(
+            'warn',
+            `Could not download file after ${
+              options.retry
+            } tries removing the file`
+          )
+        } else {
+          log('warn', 'unknown file download error: ' + err.message)
+        }
+      })
+    }
+
+    attachFileToEntry(entry, file)
+
+    sanitizeEntry(entry)
+    if (options.postProcess) {
+      await options.postProcess(entry)
+    }
+  } catch (err) {
+    if (getErrorStatus(err) === 413) {
+      // the cozy quota is full
+      throw new Error(errors.DISK_QUOTA_EXCEEDED)
+    }
+    log('warn', errors.SAVE_FILE_FAILED)
+    log(
+      'warn',
+      err.message,
+      `Error caught while trying to save the file ${
+        entry.fileurl ? entry.fileurl : entry.filename
+      }`
+    )
+  }
+  return entry
+}
+
+async function getFileIfExists(entry, options) {
+  const filePrimaryKeys = options.filePrimaryKeys
+  if (!filePrimaryKeys) {
+    log(
+      'warn',
+      `saveFiles: no deduplication key is defined, file deduplication will be based on file path`
+    )
+  }
+
+  const slug = manifest.data.slug
+  if (!slug) {
+    log(
+      'warn',
+      `saveFiles: no slug is defined for the current connector, file deduplication will be based on file path`
+    )
+  }
+
+  const sourceAccountIdentifier = get(
+    options,
+    'sourceAccountOptions.sourceAccountIdentifier'
+  )
+  if (!sourceAccountIdentifier) {
+    log(
+      'warn',
+      `saveFiles: no sourceAccountIdentifier is defined in options, file deduplication will be based on file path`
+    )
+  }
+
+  if (!filePrimaryKeys || !slug || !sourceAccountIdentifier) {
+    try {
+      const result = await cozy.files.statByPath(
+        getFilePath({ entry, options })
+      )
+      return result
+    } catch (err) {
+      log('debug', err.message)
+      return false
+    }
+  } else {
+    const index = await cozy.data.defineIndex('io.cozy.files', [
+      'metadata.filePrimaryKeys',
+      'trashed',
+      'cozyMetadata.sourceAccountIdentifier',
+      'cozyMetadata.createdByApp'
+    ])
+    const files = await queryAll(
+      'io.cozy.files',
+      {
+        metadata: {
+          filePrimaryKeys: calculateFileKey(entry, filePrimaryKeys)
+        },
+        trashed: false,
+        cozyMetadata: {
+          sourceAccountIdentifier: sourceAccountIdentifier,
+          createdByApp: slug
+        }
+      },
+      index
+    )
+    if (files && files[0]) {
+      if (files.length > 1) {
+        log(
+          'warn',
+          `Found ${files.length} files corresponding to ${calculateFileKey(
+            entry,
+            filePrimaryKeys
+          )}`
+        )
+      }
+      return files[0]
+    } else {
+      try {
+        const result = await cozy.files.statByPath(
+          getFilePath({ entry, options })
+        )
+        return result
+      } catch (err) {
+        log('debug', err.message)
+        return false
+      }
+    }
+  }
+}
+
+async function createFile(entry, options, method, fileId) {
+  const folder = await cozy.files.statByPath(options.folderPath)
+  let createFileOptions = {
+    name: getFileName(entry),
+    dirID: folder._id
+  }
+  if (options.contentType) {
+    if (options.contentType === true && entry.filename) {
+      createFileOptions.contentType = mimetypes.contentType(entry.filename)
+    } else {
+      createFileOptions.contentType = options.contentType
+    }
+  }
+  createFileOptions = {
+    ...createFileOptions,
+    ...entry.fileAttributes,
+    ...options.sourceAccountOptions
+  }
+
+  if (options.filePrimaryKeys) {
+    createFileOptions = {
+      ...createFileOptions,
+      ...{
+        metadata: {
+          filePrimaryKeys: calculateFileKey(entry, options.filePrimaryKeys)
+        }
+      }
+    }
+  }
+
+  const toCreate =
+    entry.filestream || downloadEntry(entry, { ...options, simple: false })
+  let fileDocument
+  if (method === 'create') {
+    fileDocument = await cozy.files.create(toCreate, createFileOptions)
+  } else if (method === 'updateById') {
+    log('info', `replacing file for ${entry.filename}`)
+    fileDocument = await cozy.files.updateById(
+      fileId,
+      toCreate,
+      createFileOptions
+    )
+  }
+
+  if (options.validateFile) {
+    if ((await options.validateFile(fileDocument)) === false) {
+      await removeFile(fileDocument)
+      throw new Error('BAD_DOWNLOADED_FILE')
+    }
+
+    if (
+      options.validateFileContent &&
+      !(await options.validateFileContent(fileDocument))
+    ) {
+      await removeFile(fileDocument)
+      throw new Error('BAD_DOWNLOADED_FILE')
+    }
+  }
+
+  return fileDocument
+}
+
+function downloadEntry(entry, options) {
+  let filePromise = getRequestInstance(entry, options)(
+    getRequestOptions(entry, options)
+  )
+
+  if (options.contentType) {
+    // the developper wants to foce the contentType of the document
+    // we pipe the stream to remove headers with bad contentType from the request
+    return filePromise.pipe(new stream.PassThrough())
+  }
+
+  // we have to do this since the result of filePromise is not a stream and cannot be taken by
+  // cozy.files.create
+  if (options.postProcessFile) {
+    log(
+      'warn',
+      'Be carefull postProcessFile option is deprecated. You should use the filestream attribute in each entry instead'
+    )
+    return filePromise.then(data => options.postProcessFile(data))
+  }
+  filePromise.catch(err => {
+    log('warn', `File download error ${err.message}`)
+  })
+  return filePromise
+}
+
+const shouldReplaceFile = async function(file, entry, options) {
+  const isValid = !options.validateFile || (await options.validateFile(file))
+  if (!isValid) {
+    log(
+      'warn',
+      `${getFileName({
+        file,
+        options
+      })} is invalid. Downloading it one more time`
+    )
+    throw new Error('BAD_DOWNLOADED_FILE')
+  }
+  const defaultShouldReplaceFile = (file, entry) => {
+    // replace all files with meta if there is file metadata to add
+    const fileHasNoMetadata = !getAttribute(file, 'metadata')
+    const entryHasMetadata = !!get(entry, 'fileAttributes.metadata')
+    return fileHasNoMetadata && (entryHasMetadata || options.filePrimaryKeys)
+  }
+  const shouldReplaceFileFn =
+    entry.shouldReplaceFile ||
+    options.shouldReplaceFile ||
+    defaultShouldReplaceFile
+
+  return shouldReplaceFileFn(file, entry)
+}
+
+const removeFile = async function(file) {
+  await cozy.files.trashById(file._id)
+  await cozy.files.destroyById(file._id)
+}
+
 module.exports = saveFiles
 module.exports.getFileIfExists = getFileIfExists
 
@@ -580,8 +507,8 @@ function sanitizeFileName(filename) {
 }
 
 function checkFileSize(fileobject) {
-  const size = get(fileobject, 'attributes.size', fileobject.size)
-  const name = get(fileobject, 'attributes.name', fileobject.name)
+  const size = getAttribute(fileobject, 'size')
+  const name = getAttribute(fileobject, 'name')
   if (size === 0 || size === '0') {
     log('warn', `${name} is empty`)
     log('warn', 'BAD_FILE_SIZE')
@@ -591,8 +518,8 @@ function checkFileSize(fileobject) {
 }
 
 function checkMimeWithPath(fileDocument) {
-  const mime = get(fileDocument, 'attributes.mime', fileDocument.mime)
-  const name = get(fileDocument, 'attributes.name', fileDocument.name)
+  const mime = getAttribute(fileDocument, 'mime')
+  const name = getAttribute(fileDocument, 'name')
   const extension = path.extname(name).substr(1)
   if (extension && mime && mimetypes.lookup(extension) !== mime) {
     log('warn', `${name} and ${mime} do not correspond`)
@@ -647,4 +574,81 @@ function getValOrFnResult(val, ...args) {
 
 function calculateFileKey(entry, filePrimaryKeys) {
   return filePrimaryKeys.map(key => get(entry, key)).join('####')
+}
+
+function defaultValidateFile(fileDocument) {
+  return checkFileSize(fileDocument) && checkMimeWithPath(fileDocument)
+}
+
+async function defaultValidateFileContent(fileDocument) {
+  const response = await cozy.files.downloadById(fileDocument._id)
+  const mime = getAttribute(fileDocument, 'mime')
+  const fileTypeFromContent = fileType(await response.buffer())
+  if (!fileTypeFromContent) {
+    log('warn', `Could not find mime type from file content`)
+    return false
+  }
+
+  if (!defaultValidateFile(fileDocument) || mime !== fileTypeFromContent.mime) {
+    log(
+      'warn',
+      `Wrong file type from content ${JSON.stringify(fileTypeFromContent)}`
+    )
+    return false
+  }
+  return true
+}
+
+function sanitizeEntry(entry) {
+  delete entry.requestOptions
+  delete entry.filestream
+  delete entry.shouldReplaceFile
+  return entry
+}
+
+function getRequestInstance(entry, options) {
+  return options.requestInstance
+    ? options.requestInstance
+    : requestFactory({
+        json: false,
+        cheerio: false,
+        userAgent: true,
+        jar: true
+      })
+}
+
+function getRequestOptions(entry, options) {
+  const defaultRequestOptions = {
+    uri: entry.fileurl,
+    method: 'GET'
+  }
+
+  if (!options.requestInstance) {
+    // if requestInstance is already set, we suppose that the connecteur want to handle the cookie
+    // jar itself
+    defaultRequestOptions.jar = true
+  }
+
+  return {
+    ...defaultRequestOptions,
+    ...entry.requestOptions
+  }
+}
+
+function attachFileToEntry(entry, fileDocument) {
+  entry.fileDocument = fileDocument
+  return entry
+}
+
+function getFilePath({ file, entry, options }) {
+  const folderPath = options.folderPath
+  if (file) {
+    return path.join(folderPath, getAttribute(file, 'name'))
+  } else if (entry) {
+    return path.join(folderPath, getFileName(entry))
+  }
+}
+
+function getAttribute(obj, attribute) {
+  return get(obj, `attributes.${attribute}`, obj[attribute])
 }

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -573,7 +573,10 @@ function getValOrFnResult(val, ...args) {
 }
 
 function calculateFileKey(entry, filePrimaryKeys) {
-  return filePrimaryKeys.map(key => get(entry, key)).join('####')
+  return filePrimaryKeys
+    .sort()
+    .map(key => get(entry, key))
+    .join('####')
 }
 
 function defaultValidateFile(fileDocument) {

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -66,7 +66,7 @@ const DEFAULT_RETRY = 1 // do not retry by default
  *   + `validateFile` (function) default: do not validate if file is empty or has bad mime type
  *   + `validateFileContent` (boolean or function) default false. Also check the content of the file to
  *   recognize the mime type
- *   + `filePrimaryKeys` (array). Describe which attributes of files will be taken as primary key for
+ *   + `filePrimaryKeys` (array of strings). Describe which attributes of files will be taken as primary key for
  *   files to check if they already exist, even if they are moved. If not given, the file path will
  *   used for deduplication as before.
  * @example

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
@@ -1,13 +1,22 @@
 jest.mock('./cozyclient')
 const cozyClient = require('./cozyclient')
-//jest.mock('./utils')
-//const { queryAll } = require('./utils')
+const manifest = require('./manifest')
+jest.mock('./utils')
+const { queryAll } = require('./utils')
 const logger = require('cozy-logger')
 const saveFiles = require('./saveFiles')
+const getFileIfExists = saveFiles.getFileIfExists
 const asyncResolve = val => {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve(val)
+    }, 1)
+  })
+}
+const asyncReject = val => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(val)
     }, 1)
   })
 }
@@ -176,18 +185,18 @@ describe('saveFiles', function() {
     })
   }
 
-  // // Renaming Test, not working due to not sucessfully mock updateAttributesById
+  // Renaming Test, not working due to not sucessfully mock updateAttributesById
   // describe('when entry have shouldReplaceName', () => {
   //   beforeEach(async () => {
-  //     cozyClient.files.statByPath.mockImplementation(path => {
+  //     cozyClient.files.statByPath.mockImplementation(() => {
   //       return asyncResolve({ _id: 'folderId' })
   //     })
-  //     queryAll.mockImplementation( () => {
+  //     queryAll.mockImplementation(() => {
   //       // Watch out, not the same format as cozyClient.files
-  //       return [ { name: '201712_freemobile.pdf', _id: 'idToRename' } ]
+  //       return [{ name: '201712_freemobile.pdf', _id: 'idToRename' }]
   //     })
   //     cozyClient.files.updateAttributesById.mockReset()
-  //     cozyClient.files.updateAttributesById.mockImplementation((id, obj) => {
+  //     cozyClient.files.updateAttributesById.mockImplementation(() => {
   //       return
   //     })
   //   })
@@ -197,7 +206,8 @@ describe('saveFiles', function() {
   //       date: '2017-12-12T23:00:00.000Z',
   //       vendor: 'Free Mobile',
   //       type: 'phone',
-  //       fileurl: 'https://mobile.free.fr/moncompte/index.php?page=suiviconso&action=getFacture&format=dl&l=14730097&id=7c7dfbfc8707b75fb478f68a50b42fc6&date=20171213&multi=0',
+  //       fileurl:
+  //         'https://mobile.free.fr/moncompte/index.php?page=suiviconso&action=getFacture&format=dl&l=14730097&id=7c7dfbfc8707b75fb478f68a50b42fc6&date=20171213&multi=0',
   //       filename: '201712_freemobile_nicename.pdf',
   //       shouldReplaceName: '201712_freemobile.pdf'
   //     }
@@ -220,13 +230,9 @@ describe('saveFiles', function() {
     }
   ]
   describe('when filestream is used without filename', () => {
-    it('should throw an error', async () => {
-      expect.assertions(2)
-      try {
-        await saveFiles(billWithoutFilename, options)
-      } catch (error) {
-        expect(error).toEqual(new Error('Missing filename property'))
-      }
+    it('should ignore the entry', async () => {
+      const result = await saveFiles(billWithoutFilename, options)
+      expect(result.length).toEqual(0)
       expect(cozyClient.files.create).not.toHaveBeenCalled()
     })
   })
@@ -264,6 +270,65 @@ describe('saveFiles', function() {
         { timeout: 1 }
       )
       expect(cozyClient.files.create).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('getFileIfExists', function() {
+  describe('when in filepath mode', () => {
+    beforeEach(function() {
+      manifest.data.slug = false
+      cozyClient.files.statByPath.mockReset()
+    })
+    it('when the file does not exist, should not return any file', async () => {
+      cozyClient.files.statByPath.mockReturnValue(asyncReject(false))
+      const result = await getFileIfExists(
+        { filename: 'testfile.txt' },
+        { folderPath: '/test/path' }
+      )
+      expect(result).toBe(false)
+    })
+    it('when the file exists and without metadata, should return the file', async () => {
+      cozyClient.files.statByPath.mockReturnValue(
+        asyncResolve({ name: 'testfile.txt' })
+      )
+      const result = await getFileIfExists(
+        { filename: 'testfile.txt' },
+        { folderPath: '/test/path' }
+      )
+      expect(result).toEqual({ name: 'testfile.txt' })
+    })
+  })
+  describe('when in metadata mode', () => {
+    const options = {
+      filePrimaryKeys: ['vendorRef'],
+      sourceAccountOptions: {
+        sourceAccountIdentifier: 'accountidentifier'
+      },
+      folderPath: '/test/path'
+    }
+    beforeEach(function() {
+      manifest.data.slug = 'testconnector'
+      cozyClient.data.defineIndex.mockReturnValue(asyncResolve('index'))
+      cozyClient.files.statByPath.mockReset()
+      queryAll.mockReset()
+    })
+    it('when the file does not exist, should not return any file', async () => {
+      queryAll.mockReturnValue(asyncResolve([]))
+      cozyClient.files.statByPath.mockReturnValue(asyncReject(false))
+      const result = await getFileIfExists(
+        { filename: 'testfile.txt' },
+        options
+      )
+      expect(result).toBe(false)
+    })
+    it('when the file exists, should return the file', async () => {
+      queryAll.mockReturnValue(asyncResolve([{ filename: 'coucou.txt' }]))
+      const result = await getFileIfExists(
+        { filename: 'testfile.txt' },
+        options
+      )
+      expect(result).toEqual({ filename: 'coucou.txt' })
     })
   })
 })

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
@@ -301,7 +301,7 @@ describe('getFileIfExists', function() {
   })
   describe('when in metadata mode', () => {
     const options = {
-      filePrimaryKeys: ['vendorRef'],
+      fileIdAttributes: ['vendorRef'],
       sourceAccountOptions: {
         sourceAccountIdentifier: 'accountidentifier'
       },
@@ -324,7 +324,7 @@ describe('getFileIfExists', function() {
         'io.cozy.files',
         {
           metadata: {
-            filePrimaryKeys: 'uniquevendorref'
+            fileIdAttributes: 'uniquevendorref'
           },
           trashed: false,
           cozyMetadata: {
@@ -349,7 +349,7 @@ describe('getFileIfExists', function() {
         'io.cozy.files',
         {
           metadata: {
-            filePrimaryKeys: 'uniquevendorref'
+            fileIdAttributes: 'uniquevendorref'
           },
           trashed: false,
           cozyMetadata: {
@@ -362,9 +362,9 @@ describe('getFileIfExists', function() {
       expect(result).toEqual({ filename: 'coucou.txt' })
     })
 
-    describe('when multiple filePrimaryKeys are given', () => {
+    describe('when multiple fileIdAttributes are given', () => {
       const options = {
-        filePrimaryKeys: ['vendorRef', 'amount'],
+        fileIdAttributes: ['vendorRef', 'amount'],
         sourceAccountOptions: {
           sourceAccountIdentifier: 'accountidentifier'
         },
@@ -384,7 +384,7 @@ describe('getFileIfExists', function() {
           'io.cozy.files',
           {
             metadata: {
-              filePrimaryKeys: '42####uniquevendorref'
+              fileIdAttributes: '42####uniquevendorref'
             },
             trashed: false,
             cozyMetadata: {


### PR DESCRIPTION
This PR will add the possibility to saveFiles (and saveBills) to deduplicate files using data saved in file metadata.

```js
await saveFiles([{fileurl: 'https://toto.com/15ab68', filename: 'file.txt'}], fields, {
  filePrimaryKeys: ['fileurl']
})
```

Here the file `file.txt` will be saved to the destination path with the following metadata : 

```json
{
  "filePrimaryKeys": "https://toto.com/15ab68"
}
```

Some important consequences of this PR :

 - If the filePrimaryKeys option is not used by the connector, nothing changes : the file path will be used as deduplication key
 - files which already exist but do not have metadata will be automatically updated with correct deduplication metadata if the file was not moved or renamed before.