### PR TITLE
fix: better cozy-client-js-stub for complex queries

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -69,7 +69,9 @@ module.exports = {
       const keys = Object.keys(selector)
       let result = db
         .get(doctype)
-        .filter(doc => keys.every(key => doc[key]))
+        .filter(doc =>
+          keys.every(key => doc[key] && doc[key] === selector[key])
+        )
         .value()
 
       if (options.wholeResponse) {

--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.spec.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.spec.js
@@ -53,13 +53,10 @@ describe('cozy-client-js-stub', () => {
     const index = await stub.data.defineIndex('io.cozy.bills')
     const result = await stub.data.query(index, {
       selector: {
-        mandatory: { $gt: null }
+        mandatory: 'toto'
       }
     })
-    expect(result.map(doc => omit(doc, '_id'))).toEqual([
-      { mandatory: 'toto' },
-      { mandatory: 'titi' }
-    ])
+    expect(result.map(doc => omit(doc, '_id'))).toEqual([{ mandatory: 'toto' }])
   })
   it('should get all element of a doctype', async () => {
     db.defaults({ 'io.cozy.bills': [] }).write()


### PR DESCRIPTION
This allow banking connectors to work in standalone mode