### PR TITLE
Fix cannot find module 'opn' (typo)

### DIFF
--- a/packages/cozy-jobs-cli/src/open-in-browser.js
+++ b/packages/cozy-jobs-cli/src/open-in-browser.js
@@ -1,6 +1,6 @@
 /* eslint no-console: off */
 
-const opn = require('opn')
+const open = require('open')
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
@@ -21,6 +21,6 @@ global.openInBrowser = $ => {
 
   const tmpFile = path.join(os.tmpdir(), 'cozy-run-standalone-open-file.html')
   fs.writeFileSync(tmpFile, html)
-  opn(tmpFile, { wait: false })
+  open(tmpFile, { wait: false })
   console.log(`${tmpFile} should be opened in your browser...`)
 }


### PR DESCRIPTION
When I run `yarn dev`, this error is raised : 

```bash
$ cozy-konnector-dev
internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'opn'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (~/cozy-konnector-bank-fortuneo/node_modules/cozy-jobs-cli/src/open-in-browser.js:3:13)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
```

## Environment
cozy-konnector-libs@4.21.1
cozy-jobs-cli@1.9.10