### PR TITLE
docs: Add Readme.md to TOC

### DIFF
--- a/packages/cozy-konnector-libs/README.md
+++ b/packages/cozy-konnector-libs/README.md
@@ -3,6 +3,13 @@
 
 `cozy-konnector-libs` helps you scrape and save data to your cozy.
 
-  * [API](./docs/api.md)
-  * [CLI](./docs/cli.md)
+For an easy introduction to scraping your personal data with Cozy :
 
+1. Read the [tutorial](https://docs.cozy.io/en/tutorials/konnector/).
+
+2. Check out [Ameli connector](https://github.com/konnectors/cozy-konnector-ameli.git) for a real life konnector
+
+3. Read the docs
+
+  * [API](./api.md)
+  * [CLI](./cli.md)

--- a/packages/cozy-konnector-libs/docs/toc.yml
+++ b/packages/cozy-konnector-libs/docs/toc.yml
@@ -1,3 +1,4 @@
+- "README": ./README.md
 - "API" : ./api.md
 - "CLI": ./cli.md
 - "Develop": ./dev.md


### PR DESCRIPTION
There was no README in the toc.yml of cozy-konnector-libs which made it a bit hard to understand what cozy-konnector-libs was.