### PR TITLE
docs: Use JSDoc to document params

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -983,10 +983,10 @@ It uses the account to do the communication with the user
 
 | Param | Type | Description |
 | --- | --- | --- |
-| params.type: | <code>String</code> | (default: "email") - Type of the expected 2FA code. The message displayed   to the user will depend on it. Possible values: email, sms |
-| params.timeout | <code>Number</code> | (default 3 minutes after now) - After this date, the stop will stop waiting and and an error will be shown to the user |
-| params.heartBeat | <code>Number</code> | (default: 5000) - How many milliseconds between each code check |
-| params.retry | <code>Boolean</code> | (default: false) - Is it a retry. If true, an error message will be   displayed to the user |
+| options.type | <code>String</code> | (default: "email") - Type of the expected 2FA code. The message displayed   to the user will depend on it. Possible values: email, sms |
+| options.timeout | <code>Number</code> | (default 3 minutes after now) - After this date, the stop will stop waiting and and an error will be shown to the user |
+| options.heartBeat | <code>Number</code> | (default: 5000) - How many milliseconds between each code check |
+| options.retry | <code>Boolean</code> | (default: false) - Is it a retry. If true, an error message will be   displayed to the user |
 
 **Example**  
 ```javascript

--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -803,7 +803,7 @@ Bank transactions categorization
 
 * [categorization](#module_categorization)
     * [~createCategorizer()](#module_categorization..createCategorizer) ⇒ <code>Object</code>
-    * [~categorize()](#module_categorization..categorize) ⇒ <code>Array.&lt;Object&gt;</code>
+    * [~categorize()](#module_categorization..categorize) ⇒ <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code>
 
 <a name="module_categorization..createCategorizer"></a>
 
@@ -839,11 +839,11 @@ class BankingKonnector extends BaseKonnector {
 ```
 <a name="module_categorization..categorize"></a>
 
-### categorization~categorize() ⇒ <code>Array.&lt;Object&gt;</code>
+### categorization~categorize() ⇒ <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code>
 Initialize global and local models and categorize the given array of transactions
 
 **Kind**: inner method of [<code>categorization</code>](#module_categorization)  
-**Returns**: <code>Array.&lt;Object&gt;</code> - the categorized transactions  
+**Returns**: <code>[ &#x27;Array&#x27; ].&lt;Object&gt;</code> - the categorized transactions  
 **See**: [createCategorizer](createCategorizer) for more informations about models initialization  
 **Example**  
 ```js
@@ -876,7 +876,7 @@ fetch account information for your connector.
     * [.saveAccountData(data, options)](#BaseKonnector+saveAccountData) ⇒ <code>Promise</code>
     * [.getAccountData()](#BaseKonnector+getAccountData) ⇒ <code>object</code>
     * [.updateAccountAttributes()](#BaseKonnector+updateAccountAttributes)
-    * [.waitForTwoFaCode()](#BaseKonnector+waitForTwoFaCode)
+    * [.waitForTwoFaCode()](#BaseKonnector+waitForTwoFaCode) ⇒ <code>Promise</code>
     * [.saveBills()](#BaseKonnector+saveBills) ⇒ <code>Promise</code>
     * [.saveFiles()](#BaseKonnector+saveFiles) ⇒ <code>Promise</code>
     * [.updateOrCreate()](#BaseKonnector+updateOrCreate) ⇒ <code>Promise</code>
@@ -974,23 +974,20 @@ Update account attributes and cache the account
 **Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
 <a name="BaseKonnector+waitForTwoFaCode"></a>
 
-### baseKonnector.waitForTwoFaCode()
+### baseKonnector.waitForTwoFaCode() ⇒ <code>Promise</code>
 Notices that 2FA code is needed and wait for the user to submit it.
 It uses the account to do the communication with the user
 
-Parameters:
-
-- `params` object with some mandatory attributes :
-  + `type` (String): (default email) this is the type of expected 2FA code. The message displayed
-  to the user will follow it. Possible values: email, sms
-  + `timeout` (Number): (default 3 minutes after now) time when the function will stop waiting
-  for a code and fail
-  + `heartBeat` (Number): (default 5s) how much time is waited between each code check
-  + `retry` (boolen): (default false) is it a retry. If true, an error message will be
-  displayed to the user
-Returns: Promise with sucessfull code if any
-
 **Kind**: instance method of [<code>BaseKonnector</code>](#BaseKonnector)  
+**Returns**: <code>Promise</code> - Contains twoFa code entered by user  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| params.type: | <code>String</code> | (default: "email") - Type of the expected 2FA code. The message displayed   to the user will depend on it. Possible values: email, sms |
+| params.timeout | <code>Number</code> | (default 3 minutes after now) - After this date, the stop will stop waiting and and an error will be shown to the user |
+| params.heartBeat | <code>Number</code> | (default: 5000) - How many milliseconds between each code check |
+| params.retry | <code>Boolean</code> | (default: false) - Is it a retry. If true, an error message will be   displayed to the user |
+
 **Example**  
 ```javascript
 const { BaseKonnector } = require('cozy-konnector-libs')

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -216,17 +216,15 @@ class BaseKonnector {
    * Notices that 2FA code is needed and wait for the user to submit it.
    * It uses the account to do the communication with the user
    *
-   * Parameters:
-   *
-   * - `params` object with some mandatory attributes :
-   *   + `type` (String): (default email) this is the type of expected 2FA code. The message displayed
-   *   to the user will follow it. Possible values: email, sms
-   *   + `timeout` (Number): (default 3 minutes after now) time when the function will stop waiting
-   *   for a code and fail
-   *   + `heartBeat` (Number): (default 5s) how much time is waited between each code check
-   *   + `retry` (boolen): (default false) is it a retry. If true, an error message will be
+   * @param {String} params.type (default: "email") - Type of the expected 2FA code. The message displayed
+   *   to the user will depend on it. Possible values: email, sms
+   * @param {Number} params.timeout (default 3 minutes after now) - After this date, the stop will stop waiting and
+   * and an error will be shown to the user
+   * @param {Number} params.heartBeat (default: 5000) - How many milliseconds between each code check
+   * @param {Boolean} params.retry (default: false) - Is it a retry. If true, an error message will be
    *   displayed to the user
-   * Returns: Promise with sucessfull code if any
+   *
+   * @returns {Promise} Contains twoFa code entered by user
    *
    * @example
    *

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -216,12 +216,12 @@ class BaseKonnector {
    * Notices that 2FA code is needed and wait for the user to submit it.
    * It uses the account to do the communication with the user
    *
-   * @param {String} params.type (default: "email") - Type of the expected 2FA code. The message displayed
+   * @param {String} options.type (default: "email") - Type of the expected 2FA code. The message displayed
    *   to the user will depend on it. Possible values: email, sms
-   * @param {Number} params.timeout (default 3 minutes after now) - After this date, the stop will stop waiting and
+   * @param {Number} options.timeout (default 3 minutes after now) - After this date, the stop will stop waiting and
    * and an error will be shown to the user
-   * @param {Number} params.heartBeat (default: 5000) - How many milliseconds between each code check
-   * @param {Boolean} params.retry (default: false) - Is it a retry. If true, an error message will be
+   * @param {Number} options.heartBeat (default: 5000) - How many milliseconds between each code check
+   * @param {Boolean} options.retry (default: false) - Is it a retry. If true, an error message will be
    *   displayed to the user
    *
    * @returns {Promise} Contains twoFa code entered by user
@@ -243,7 +243,7 @@ class BaseKonnector {
    * }
    * ```
    */
-  async waitForTwoFaCode(params = {}) {
+  async waitForTwoFaCode(options = {}) {
     if (process.env.COZY_JOB_MANUAL_EXECUTION !== 'true') {
       log(
         'warn',
@@ -259,16 +259,16 @@ class BaseKonnector {
       heartBeat: 5000,
       retry: false
     }
-    params = { ...defaultParams, ...params }
+    options = { ...defaultParams, ...options }
     let account = {}
-    let state = params.retry ? 'TWOFA_NEEDED_RETRY' : 'TWOFA_NEEDED'
-    if (params.type === 'email') state += '.EMAIL'
-    if (params.type === 'sms') state += '.SMS'
+    let state = options.retry ? 'TWOFA_NEEDED_RETRY' : 'TWOFA_NEEDED'
+    if (options.type === 'email') state += '.EMAIL'
+    if (options.type === 'sms') state += '.SMS'
     log('info', `Setting ${state} state into the current account`)
     await this.updateAccountAttributes({ state, twoFACode: null })
 
-    while (Date.now() < params.timeout && !account.twoFACode) {
-      await sleep(params.heartBeat)
+    while (Date.now() < options.timeout && !account.twoFACode) {
+      await sleep(options.heartBeat)
       account = await cozy.data.find('io.cozy.accounts', this.accountId)
       log('info', `current accountState : ${account.state}`)
       log('info', `current twoFACode : ${account.twoFACode}`)


### PR DESCRIPTION
`@param` is used to document parameter. EDIT: The extra colon with param type is not there in the final doc.

<img width="707" alt="image" src="https://user-images.githubusercontent.com/465582/63585933-7f23c280-c5a0-11e9-95dc-a34d711c3ea6.png">
