### PR TITLE
feat(BaseKonnector/2fa): change timeout option to endTime

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -984,7 +984,8 @@ It uses the account to do the communication with the user
 | Param | Type | Description |
 | --- | --- | --- |
 | options.type | <code>String</code> | (default: "email") - Type of the expected 2FA code. The message displayed   to the user will depend on it. Possible values: email, sms |
-| options.timeout | <code>Number</code> | (default 3 minutes after now) - After this date, the stop will stop waiting and and an error will be shown to the user |
+| options.timeout | <code>Number</code> | (default 3 minutes after now) - After this date, the stop will stop waiting and and an error will be shown to the user (deprecated and alias of endTime) |
+| options.endTime | <code>Number</code> | (default 3 minutes after now) - After this timestamp, the home will stop waiting and and an error will be shown to the user |
 | options.heartBeat | <code>Number</code> | (default: 5000) - How many milliseconds between each code check |
 | options.retry | <code>Boolean</code> | (default: false) - Is it a retry. If true, an error message will be   displayed to the user |
 
@@ -997,8 +998,7 @@ module.exports = new BaseKonnector(start)
 async function start() {
    // we detect the need of a 2FA code
    const code = this.waitForTwoFaCode({
-     type: 'email',
-     timeout: 5 * 60 * 1000
+     type: 'email'
    })
    // send the code to the targeted site
 }

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -214,6 +214,8 @@ class BaseKonnector {
    * @param {String} options.type (default: "email") - Type of the expected 2FA code. The message displayed
    *   to the user will depend on it. Possible values: email, sms
    * @param {Number} options.timeout (default 3 minutes after now) - After this date, the stop will stop waiting and
+   * and an error will be shown to the user (deprecated and alias of endTime)
+   * @param {Number} options.endTime (default 3 minutes after now) - After this timestamp, the home will stop waiting and
    * and an error will be shown to the user
    * @param {Number} options.heartBeat (default: 5000) - How many milliseconds between each code check
    * @param {Boolean} options.retry (default: false) - Is it a retry. If true, an error message will be
@@ -231,8 +233,7 @@ class BaseKonnector {
    * async function start() {
    *    // we detect the need of a 2FA code
    *    const code = this.waitForTwoFaCode({
-   *      type: 'email',
-   *      timeout: 5 * 60 * 1000
+   *      type: 'email'
    *    })
    *    // send the code to the targeted site
    * }
@@ -250,11 +251,18 @@ class BaseKonnector {
     const startTime = Date.now()
     const defaultParams = {
       type: 'email',
-      timeout: startTime + 3 * 60 * 1000,
+      endTime: startTime + 3 * 60 * 1000,
       heartBeat: 5000,
       retry: false
     }
     options = { ...defaultParams, ...options }
+    if (options.timeout) {
+      log(
+        'warn',
+        `The timeout option for waitForTwoFaCode is deprecated. Please use the endTime option now`
+      )
+      options.endTime = options.timeout
+    }
     let account = {}
     let state = options.retry ? 'TWOFA_NEEDED_RETRY' : 'TWOFA_NEEDED'
     if (options.type === 'email') state += '.EMAIL'
@@ -262,7 +270,7 @@ class BaseKonnector {
     log('info', `Setting ${state} state into the current account`)
     await this.updateAccountAttributes({ state, twoFACode: null })
 
-    while (Date.now() < options.timeout && !account.twoFACode) {
+    while (Date.now() < options.endTime && !account.twoFACode) {
       await sleep(options.heartBeat)
       account = await cozy.data.find('io.cozy.accounts', this.accountId)
       log('info', `current accountState : ${account.state}`)

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
@@ -39,11 +39,11 @@ describe('BaseKonnector', () => {
     )
   })
 
-  it('waitForTwoFaCode should throw on timeout', async () => {
+  it('waitForTwoFaCode should throw on endTime', async () => {
     client.data.find.mockReturnValue(asyncResolve({ twoFACode: null }))
     client.data.updateAttributes.mockReturnValue(asyncResolve({}))
     try {
-      await konn.waitForTwoFaCode({ timeout: Date.now() })
+      await konn.waitForTwoFaCode({ endTime: Date.now() })
     } catch (err) {
       expect(err.message).toEqual('USER_ACTION_NEEDED.TWOFA_EXPIRED')
     }


### PR DESCRIPTION
A new `endTime` option is possible in `waitForTwoFaCode` which is an alias of `timeout` option.

The `timeout` option is now deprecated

Fixes #571