### PR TITLE
fix(cozy-client-js-stub): handle file metadata

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -475,7 +475,7 @@ const shouldReplaceFile = async function(file, entry, options) {
       `${getFileName({
         file,
         options
-      })} is invalid. Downloading it one more time`
+      })} is invalid`
     )
     throw new Error('BAD_DOWNLOADED_FILE')
   }


### PR DESCRIPTION
This will allow file deduplication to work in standalone mode