### PR TITLE
docs(cozy-konnector-libs): Add categorization dashboard docs

### DIFF
--- a/packages/cozy-konnector-libs/docs/categorization-dashboard.md
+++ b/packages/cozy-konnector-libs/docs/categorization-dashboard.md
@@ -1,0 +1,26 @@
+# Categorization dashboard
+
+To check that the categorization works well, we have tests that generate a dashboard showing global and local models performances.
+
+## Run tests
+
+Since these tests are executed on real data, the data is encrypted. To be able to run the tests, you have to decrypt it:
+
+```
+yarn decrypt-banking-tests
+```
+
+The global categorization model tests also needs the current and latest model parameters. These parameters should be downloaded:
+
+```
+yarn download-banking-tests
+```
+
+Now you have everything to run the tests.
+
+```
+env BACKUP_DIR=/path/to/dir yarn jest src/ducks/categorization/services-fixtures.spec.js
+```
+
+* `BACKUP_DIR` environment variable is the path to the directory in which you want to write the result of the tests (csv and txt files)
+* You can add the jest flags you need: `-u` to update snapshots and `--watch` to run the tests in watch mode, for example


### PR DESCRIPTION
The categorization dashboard code lives in cozy-konnector-libs since
https://github.com/konnectors/libs/pull/476, but the docs were still in
cozy-banks repo.