### PR TITLE
Refactor error handling

### DIFF
--- a/packages/cozy-konnector-libs/src/index.js
+++ b/packages/cozy-konnector-libs/src/index.js
@@ -3,8 +3,6 @@ const requestFactory = require('./libs/request')
 const hydrateAndFilter = require('./libs/hydrateAndFilter')
 const categorization = require('./libs/categorization')
 
-require('./libs/error')
-
 module.exports = {
   BaseKonnector: require('./libs/BaseKonnector'),
   CookieKonnector: require('./libs/CookieKonnector'),

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -18,6 +18,8 @@ const sleep = require('util').promisify(global.setTimeout)
 const LOG_ERROR_MSG_LIMIT = 32 * 1024 - 1 // to avoid to cut the json long and make it unreadable by the stack
 const once = require('lodash/once')
 
+const errors = require('./error')
+
 const findFolderPath = async (cozyFields, account) => {
   // folderId will be stored in cozyFields.folder_to_save on first run
   if (!cozyFields.folder_to_save) {
@@ -104,6 +106,8 @@ class BaseKonnector {
     this.deactivateAutoSuccessfulLogin = once(
       this.deactivateAutoSuccessfulLogin
     )
+
+    errors.attachProcessEventHandlers()
   }
 
   /**

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -116,10 +116,13 @@ class BaseKonnector {
    */
   async run() {
     try {
+      log('info', 'Preparing konnector...')
       await this.initAttributes()
+      log('info', 'Running konnector main...')
       await this.main(this.fields, this.parameters)
       await this.end()
     } catch (err) {
+      log('warn', 'Error from konnector')
       await this.fail(err)
     }
   }
@@ -178,6 +181,10 @@ class BaseKonnector {
 
     // Set account
     const account = await this.getAccount(cozyFields.account)
+    log('info', `Cached Cozy account ${JSON.stringify(account)}`)
+    if (!account || !account._id) {
+      log('warn', 'No account was retrieved from getAccount')
+    }
     this.accountId = account._id
     this._account = account
 

--- a/packages/cozy-konnector-libs/src/libs/error.js
+++ b/packages/cozy-konnector-libs/src/libs/error.js
@@ -43,10 +43,10 @@ const attachProcessEventHandlers = (prcs = process) => {
 
   return () => {
     attached = false
-    prcs.off('uncaughtException', handleUncaughtException)
-    prcs.off('unhandledRejection', handleUnhandledRejection)
-    prcs.off('SIGTERM', handleSigterm)
-    prcs.off('SIGINT', handleSigint)
+    prcs.removeEventListener('uncaughtException', handleUncaughtException)
+    prcs.removeEventListener('unhandledRejection', handleUnhandledRejection)
+    prcs.removeEventListener('SIGTERM', handleSigterm)
+    prcs.removeEventListener('SIGINT', handleSigint)
   }
 }
 

--- a/packages/cozy-konnector-libs/src/libs/error.js
+++ b/packages/cozy-konnector-libs/src/libs/error.js
@@ -1,19 +1,55 @@
 const log = require('cozy-logger').namespace('Error Interception')
 
-// This will catch exception which would be uncaught by the connector script itself
-process.on('uncaughtException', err => {
+const handleUncaughtException = err => {
   log('critical', err.message, 'uncaught exception')
   process.exit(1)
-})
-process.on('unhandledRejection', err => {
+}
+
+const handleUnhandledRejection = err => {
   log('critical', err.message, 'unhandled exception')
   process.exit(1)
-})
-process.on('SIGTERM', () => {
+}
+
+const handleSigterm = () => {
   log('critical', 'The konnector got a SIGTERM')
   process.exit(128 + 15)
-})
-process.on('SIGINT', () => {
+}
+
+const handleSigint = () => {
   log('critical', 'The konnector got a SIGINT')
   process.exit(128 + 2)
-})
+}
+
+let attached = false
+
+/**
+ * Attach event handlers to catch uncaught exceptions/rejections and signals.
+ * Log them as critical and exit the process accordingly.
+ * If the cleanup function has not been called, calling again the function
+ * is a no-op.
+ *
+ * @param  {Process} prcs - Process object, default to current process
+ * @return {Function} When called, removes the signal handlers
+ */
+const attachProcessEventHandlers = (prcs = process) => {
+  if (attached) {
+    return
+  }
+  attached = true
+  prcs.on('uncaughtException', handleUncaughtException)
+  prcs.on('unhandledRejection', handleUnhandledRejection)
+  prcs.on('SIGTERM', handleSigterm)
+  prcs.on('SIGINT', handleSigint)
+
+  return () => {
+    attached = false
+    prcs.off('uncaughtException', handleUncaughtException)
+    prcs.off('unhandledRejection', handleUnhandledRejection)
+    prcs.off('SIGTERM', handleSigterm)
+    prcs.off('SIGINT', handleSigint)
+  }
+}
+
+module.exports = {
+  attachProcessEventHandlers
+}

--- a/packages/cozy-konnector-libs/src/libs/error.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/error.spec.js
@@ -1,0 +1,19 @@
+const { attachProcessEventHandlers } = require('./error')
+
+describe('error handling', () => {
+  it('should attach handlers', () => {
+    const process = {
+      on: jest.fn(),
+      off: jest.fn()
+    }
+
+    const cleanup = attachProcessEventHandlers(process)
+    expect(process.on).toHaveBeenCalledTimes(4)
+    attachProcessEventHandlers(process)
+    expect(process.on).toHaveBeenCalledTimes(4)
+    cleanup()
+    expect(process.off).toHaveBeenCalledTimes(4)
+    attachProcessEventHandlers(process)
+    expect(process.on).toHaveBeenCalledTimes(8)
+  })
+})

--- a/packages/cozy-konnector-libs/src/libs/error.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/error.spec.js
@@ -4,7 +4,7 @@ describe('error handling', () => {
   it('should attach handlers', () => {
     const process = {
       on: jest.fn(),
-      off: jest.fn()
+      removeEventListener: jest.fn()
     }
 
     const cleanup = attachProcessEventHandlers(process)
@@ -12,7 +12,7 @@ describe('error handling', () => {
     attachProcessEventHandlers(process)
     expect(process.on).toHaveBeenCalledTimes(4)
     cleanup()
-    expect(process.off).toHaveBeenCalledTimes(4)
+    expect(process.removeEventListener).toHaveBeenCalledTimes(4)
     attachProcessEventHandlers(process)
     expect(process.on).toHaveBeenCalledTimes(8)
   })

--- a/packages/cozy-konnector-libs/src/libs/mkdirp.js
+++ b/packages/cozy-konnector-libs/src/libs/mkdirp.js
@@ -5,8 +5,6 @@
 const { basename, dirname, join } = require('path').posix
 const cozyClient = require('./cozyclient')
 
-const log = () => {}
-
 /**
  * Creates a directory and its missing ancestors as needed.
  *
@@ -44,33 +42,26 @@ mkdirp.fromCozy = fromCozy
 function fromCozy(cozy) {
   return async function mkdirp(...pathComponents) {
     const path = join('/', ...pathComponents)
-    const pathRepr = JSON.stringify(path)
 
-    log('debug', `Checking wether directory ${pathRepr} exists...`)
     let doc = null
     try {
       doc = await cozy.files.statByPath(path)
-      log('debug', `Directory ${pathRepr} found.`)
       return doc
     } catch (err) {
       if (![404, 409].includes(err.status)) throw err
-      log('debug', `Directory ${pathRepr} not found.`)
 
       const name = basename(path)
       const parentPath = dirname(path)
       const parentDoc = await mkdirp(parentPath)
 
-      log('info', `Creating directory ${pathRepr}...`)
       try {
         doc = await cozy.files.createDirectory({
           name,
           dirID: parentDoc._id
         })
-        log('info', `Directory ${pathRepr} created!`)
         return doc
       } catch (createErr) {
         if (![404, 409].includes(createErr.status)) throw createErr
-        log('info', 'Directory already exists')
         return doc
       }
     }


### PR DESCRIPTION
Instead of binding error handlers at import time, bind them
when BaseKonnector is built, it is cleaner. I don't remember
specifically why I started this refactor, but it was lingering
on my local branches.