### PR TITLE
docs: Update links to cozy-client-js

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -1,5 +1,5 @@
 /**
- * [cozy-client-js](https://cozy.github.io/cozy-client-js/) instance already
+ * [cozy-client-js](https://github.com/cozy/cozy-client-js) instance already
  * initialized and ready to use.
  *
  * @module cozyClient
@@ -82,11 +82,11 @@ const getCozyClient = function(environment = 'production') {
 }
 
 /**
- * [cozy-client-js](https://cozy.github.io/cozy-client-js/) instance already initialized and ready to use.
+ * [cozy-client-js](https://github.com/cozy/cozy-client-js) instance already initialized and ready to use.
  *
  * If you want to access cozy-client-js directly, this method gives you directly an instance of it,
  * initialized according to `COZY_URL` and `COZY_CREDENTIALS` environment variable given by cozy-stack
- * You can refer to the [cozy-client-js documentation](https://cozy.github.io/cozy-client-js/) for more information.
+ * You can refer to the [cozy-client-js documentation](https://github.com/cozy/cozy-client-js) for more information.
  *
  * Example :
  *


### PR DESCRIPTION
Those links are already broken, but give the work done on https://github.com/cozy/cozy-client-js/pull/301 we should use direct link to cozy-client-js github repo 