### PR TITLE
fix: avoid pdfjs warning on bad api usage

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/utils.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.js
@@ -243,7 +243,7 @@ const getPdfText = async (fileId, options = {}) => {
   }
   const response = await cozyClient.files.downloadById(fileId)
   const buffer = await response.buffer()
-  const document = await pdfjs.getDocument(buffer)
+  const document = await pdfjs.getDocument(buffer).promise
   let pages
   if (options.pages) {
     pages = Array.isArray(options.pages) ? options.pages : [options.pages]


### PR DESCRIPTION
Deprecated API usage: PDFDocumentLoadingTask.then method, use the  getter instead.