### PR TITLE
feat: now use cozy-client's createClientInteractive

### DIFF
--- a/packages/cozy-jobs-cli/package.json
+++ b/packages/cozy-jobs-cli/package.json
@@ -25,7 +25,6 @@
     "cli-highlight": "2.1.4",
     "commander": "4.1.1",
     "cozy-client": "12.5.0",
-    "cozy-client-js": "0.16.4",
     "cozy-konnector-libs": "^4.33.0",
     "cozy-logger": "1.6.0",
     "open": "7.0.2",

--- a/packages/cozy-jobs-cli/package.json
+++ b/packages/cozy-jobs-cli/package.json
@@ -24,7 +24,7 @@
     "cheerio": "1.0.0-rc.3",
     "cli-highlight": "2.1.4",
     "commander": "4.1.1",
-    "cozy-client": "12.5.0",
+    "cozy-client": "13.1.0",
     "cozy-konnector-libs": "^4.33.0",
     "cozy-logger": "1.6.0",
     "open": "7.0.2",

--- a/packages/cozy-jobs-cli/src/konnector-dev.js
+++ b/packages/cozy-jobs-cli/src/konnector-dev.js
@@ -102,11 +102,14 @@ const main = async () => {
 }
 
 const launchKonnector = async ({ manifest, token, file, createAccount }) => {
-  const { creds } = await authenticate({
+  const client = await authenticate({
     tokenPath: token,
     manifestPath: manifest
   })
-  process.env.COZY_CREDENTIALS = JSON.stringify(creds)
+  process.env.COZY_CREDENTIALS = JSON.stringify({
+    oauthOptions: client.stackClient.oauthOptions,
+    token: client.stackClient.token
+  })
 
   if (createAccount) {
     await ensureStackAccount(config)

--- a/packages/cozy-jobs-cli/src/run-dev.js
+++ b/packages/cozy-jobs-cli/src/run-dev.js
@@ -44,9 +44,11 @@ process.env.COZY_URL = process.env.COZY_URL
   : 'http://cozy.tools:8080'
 
 authenticate({ tokenPath: token, manifestPath: manifest })
-  .then(result => {
-    const credentials = result.creds
-    process.env.COZY_CREDENTIALS = JSON.stringify(credentials)
+  .then(client => {
+    process.env.COZY_CREDENTIALS = JSON.stringify({
+      oauthOptions: client.stackClient.oauthOptions,
+      token: client.stackClient.token
+    })
   })
   .then(() => {
     const spawned = spawn(program.args[0], program.args.slice(1), {

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -24,7 +24,7 @@
     "btoa": "1.2.1",
     "cheerio": "^1.0.0-rc.3",
     "classificator": "^0.3.3",
-    "cozy-client": "^12.0.0",
+    "cozy-client": "^13.1.0",
     "cozy-client-js": "^0.16.4",
     "cozy-doctypes": "^1.72.0",
     "cozy-logger": "^1.6.0",

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -11,70 +11,38 @@ const { Client, MemoryStorage } = require('cozy-client-js')
 const NewCozyClient = require('cozy-client').default
 const manifest = require('./manifest')
 
-const getCredentials = function(environment) {
-  try {
-    if (environment === 'development') {
-      const credentials = JSON.parse(process.env.COZY_CREDENTIALS)
-      credentials.token.toAuthHeader = function() {
-        return 'Bearer ' + credentials.client.registrationAccessToken
-      }
-      return credentials
-    } else {
-      return process.env.COZY_CREDENTIALS.trim()
-    }
-  } catch (err) {
-    console.error(
-      `Please provide proper COZY_CREDENTIALS environment variable. ${process.env.COZY_CREDENTIALS} is not OK`
-    )
-    throw err
-  }
-}
-
-const getCozyUrl = function() {
-  if (process.env.COZY_URL === undefined) {
-    console.error(`Please provide COZY_URL environment variable.`)
-    throw new Error('COZY_URL environment variable is absent/not valid')
-  } else {
-    return process.env.COZY_URL
-  }
-}
-
 const getCozyClient = function(environment = 'production') {
   if (environment === 'standalone' || environment === 'test') {
     return require('../helpers/cozy-client-js-stub')
   }
 
-  const credentials = getCredentials(environment)
-  const cozyURL = getCozyUrl()
-
-  const options = {
-    cozyURL: cozyURL
-  }
-
-  if (environment === 'development') {
-    options.oauth = { storage: new MemoryStorage() }
-  } else if (environment === 'production') {
-    options.token = credentials
-  }
-
-  const cozyClient = new Client(options)
-
-  let token = credentials
-  if (environment === 'development') {
-    cozyClient.saveCredentials(credentials.client, credentials.token)
-    token = credentials.token.accessToken
-  }
-
   const cozyFields = JSON.parse(process.env.COZY_FIELDS || '{}')
-  cozyClient.new = new NewCozyClient({
-    uri: cozyURL,
-    token,
+  const newCozyClient = NewCozyClient.fromEnv(process.env, {
     appMetadata: {
       slug: manifest.data.slug,
       sourceAccount: cozyFields.account,
       version: manifest.data.version
     }
   })
+
+  const options = {
+    cozyURL: newCozyClient.stackClient.uri
+  }
+  if (environment === 'development') {
+    options.oauth = { storage: new MemoryStorage() }
+  } else if (environment === 'production') {
+    options.token = process.env.COZY_CREDENTIALS
+  }
+  const cozyClient = new Client(options)
+  if (environment === 'development') {
+    const credentials = JSON.parse(process.env.COZY_CREDENTIALS)
+    credentials.token.toAuthHeader = function() {
+      return 'Bearer ' + credentials.client.registrationAccessToken
+    }
+    cozyClient.saveCredentials(credentials.oauthOptions, credentials.token)
+  }
+
+  cozyClient.new = newCozyClient
 
   return cozyClient
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,7 +3899,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cozy-client-js@0.16.4, cozy-client-js@^0.16.4:
+cozy-client-js@^0.16.4:
   version "0.16.4"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.16.4.tgz#2f902bb985b3d8babb925d3f889f423aceb7f676"
   integrity sha512-xiW+RpOMo3gPuvUcOx8+VtVRmLjxcTv8ZKHgbKifUa5r+T/qTpibswA5/46AGaWsLLa75tbGnoWUnIiyoe5Tcw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,15 +3909,15 @@ cozy-client-js@^0.16.4:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@12.5.0, cozy-client@^12.0.0:
-  version "12.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-12.5.0.tgz#9d49acfcc7ff9e5b41fe255c888ce67ca762170b"
-  integrity sha512-ZJFtAwtShbn1/WsG4+UJkxSC5YmmBUaNreUaN8vMufebYcfnmzrw1MA/OUlV8PN+kY+xeRGp5VmBC1cKx4EXJg==
+cozy-client@13.1.0, cozy-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.1.0.tgz#a207aed8446b7e9f30dcf5d0704852c588dee8f5"
+  integrity sha512-ARTSCUPW/uKlMOfuaFv2uyI//wueRwNhH5WZyit2MsV2jJUQLKUhWtR+pfA1YBNK8+IhPgc72PsHGCVWV2W6Kw==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^12.5.0"
+    cozy-stack-client "^13.1.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -3957,10 +3957,10 @@ cozy-logger@1.6.0, cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^12.5.0:
-  version "12.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-12.5.0.tgz#ee0377f8aa04392d697195cdbc32e66644410136"
-  integrity sha512-DkxERk9QUqsZ0WuC6qfLEqLOgPETmu/pU/tegVxjvP+1q2G4OcPL6fG0nOQOXVfm/lom0w2C8cTfPSUY8qoy1A==
+cozy-stack-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.1.0.tgz#72a1c8a9b4c3c24e32f0d6ff66c46b576cad9827"
+  integrity sha512-5DavkdIrLsOVdHBkvTmzrjVzSMh5S2utF1dW+1zfCYAUde7/XbPDRK6S2ct+Lfd0NcRbUK2oJUEpyNXMBqrrjw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
This removes cozy-client-js from cozy-jobs-cli as a direct dependency and prepares migration to
cozy-client in cozy-konnector-libs.
Now a cozy-client instance is created and the cozy-client-js instance is created from it in
cozy-konnector-libs.
konnector-dev and run-dev depend on https://github.com/cozy/cozy-client/pull/655 to be published
to work as expected