### PR TITLE
feat: now use cozy-client's createClientInteractive

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/request/request.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.js
@@ -74,12 +74,15 @@
 
 let request = require('request-promise')
 const requestdebug = require('request-debug')
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:74.0) Gecko/20100101 Firefox/74.0'
 
 exports = module.exports = {
   default: requestFactory,
   mergeDefaultOptions,
   transformWithCheerio,
-  getRequestOptions
+  getRequestOptions,
+  DEFAULT_USER_AGENT
 }
 
 function requestFactory({ debug, ...options } = { debug: false }) {
@@ -179,16 +182,14 @@ function transformWithCheerio(body, response, resolveWithFullResponse) {
 }
 
 function getRequestOptions({ cheerio, userAgent, ...options }) {
+  const userAgentOption = options.headers['User-Agent']
   return cheerio
     ? {
         ...options,
         transform: transformWithCheerio,
         headers: {
           ...options.headers,
-          'User-Agent':
-            userAgent === undefined || userAgent
-              ? DEFAULT_USER_AGENT
-              : options.headers['User-Agent']
+          'User-Agent': userAgentOption ? userAgentOption : (userAgent === false ? undefined : DEFAULT_USER_AGENT)
         }
       }
     : {
@@ -201,6 +202,3 @@ function getRequestOptions({ cheerio, userAgent, ...options }) {
         }
       }
 }
-
-const DEFAULT_USER_AGENT =
-  'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0'

--- a/packages/cozy-konnector-libs/src/libs/request/request.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.spec.js
@@ -1,4 +1,4 @@
-const { default: requestFactory, ...request } = require('./request')
+const { default: requestFactory, DEFAULT_USER_AGENT, ...request } = require('./request')
 
 describe('requestFactory', () => {
   describe('get request options', () => {
@@ -21,9 +21,7 @@ describe('requestFactory', () => {
         })
       )
       expect(options.transform).toBeDefined()
-      expect(options.headers['User-Agent']).toBe(
-        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0'
-      )
+      expect(options.headers['User-Agent']).toBe(DEFAULT_USER_AGENT)
     })
     test('user-defined UserAgent is preserved', () => {
       const options = getRequestOptions(
@@ -43,9 +41,19 @@ describe('requestFactory', () => {
         })
       )
       expect(options.transform).toBeDefined()
-      expect(options.headers['User-Agent']).toBe(
-        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0'
+      expect(options.headers['User-Agent']).toBe(DEFAULT_USER_AGENT)
+    })
+    test('with cheerio and user defined userAgent preserve user agent', () => {
+      const options = getRequestOptions(
+        mergeDefaultOptions({
+          cheerio: true,
+          headers: {
+            'User-Agent': 'My specific User-Agent'
+          }
+        })
       )
+      expect(options.transform).toBeDefined()
+      expect(options.headers['User-Agent']).toBe('My specific User-Agent')
     })
   })
 


### PR DESCRIPTION
This removes cozy-client-js from cozy-jobs-cli as a direct dependency and prepares migration to
cozy-client in cozy-konnector-libs.
Now a cozy-client instance is created and the cozy-client-js instance is created from it in
cozy-konnector-libs.
konnector-dev and run-dev depend on https://github.com/cozy/cozy-client/pull/655 to be published
to work as expected