### PR TITLE
fix: Do not register client in library

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/parameters.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/parameters.js
@@ -1,9 +1,4 @@
-const cozyClient = require('../../cozyclient')
 const { BankTransaction } = require('cozy-doctypes')
-
-if (!BankTransaction.cozyClient) {
-  BankTransaction.registerClient(cozyClient)
-}
 
 async function fetchTransactionsWithManualCat() {
   const transactionsWithManualCat = await BankTransaction.queryAll({


### PR DESCRIPTION
1. client could have been registered on Document directly and in this
   case, BankTransaction.cozyClient is the wrong check
2. library code should not register the client, it should be up to
   to the app