### PR TITLE
chore(renovate-config-cozy-konnector): automerge main dev dependencies

### DIFF
--- a/packages/renovate-config-cozy-konnector/package.json
+++ b/packages/renovate-config-cozy-konnector/package.json
@@ -13,8 +13,25 @@
       "packageRules": [
         {
           "packagePatterns": [
-            "^cozy-konnector-libs",
-            "^cozy-jobs-cli"
+            "copy-webpack-plugin",
+            "eslint-config-cozy-app",
+            "git-directory-deploy",
+            "husky",
+            "svgo",
+            "webpack",
+            "webpack-cli"
+          ],
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
+        },
+        {
+          "packagePatterns": [
+            "cozy-konnector-libs",
+            "cozy-jobs-cli",
+            "cozy-app-publish",
+            "eslint-config-cozy-app"
           ],
           "schedule": "at any time",
           "automerge": true,


### PR DESCRIPTION
Major updates excepted

copy-webpack-plugin, cozy-app-publish, eslint-config-cozy-app, git-directory-deploy, husky, svgo, webpack, webpack-cli