### PR TITLE
fix: avoid date-fns error when built with webpack

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/operationsFilters.js
+++ b/packages/cozy-konnector-libs/src/libs/linker/billsToOperation/operationsFilters.js
@@ -1,7 +1,7 @@
 const includes = require('lodash/includes')
 const some = require('lodash/some')
 const sumBy = require('lodash/sumBy')
-const isWithinInterval = require('date-fns/isWithinInterval')
+const { isWithinInterval } = require('date-fns')
 
 const {
   getIdentifiers,


### PR DESCRIPTION
Or else it whould cause a "isWithinInterval is not a function" error