### PR TITLE
fix: regression in cozy-client with isomorphic-fetch v3.0

### DIFF
--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -34,6 +34,7 @@
     "lodash-id": "^0.14.0",
     "lowdb": "^1.0.0",
     "mime-types": "^2.1.27",
+    "node-fetch": "^2.6.1",
     "raven": "^2.6.4",
     "raw-body": "^2.4.1",
     "request": "^2.88.2",

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -9,6 +9,8 @@
 
 const { Client, MemoryStorage } = require('cozy-client-js')
 const NewCozyClient = require('cozy-client').default
+// fixes an import problem of isomorphic fetch in cozy-client and cozy-client-js
+global.fetch = require('node-fetch').default
 const manifest = require('./manifest')
 
 const getCozyClient = function(environment = 'production') {


### PR DESCRIPTION
cozy-client-js does not support to be imported in a webpack archive since isomorphic-fetch v3 is included.
This initializes the right form of node-fetch in global.fetch global variable.