### PR TITLE
fix: env mode recognition

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/manifest.js
+++ b/packages/cozy-konnector-libs/src/libs/manifest.js
@@ -17,7 +17,7 @@ let manifest =
     ? {}
     : __WEBPACK_PROVIDED_MANIFEST__
 
-if (process.env.NODE_ENV !== 'none' && process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV !== 'none' && process.env.NODE_ENV !== 'production') {
   try {
     manifest = getManifestFromFile()
   } catch (err) {

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -204,7 +204,7 @@ const saveEntry = async function(entry, options) {
     try {
       shouldReplace = await shouldReplaceFile(file, entry, options)
     } catch (err) {
-      log('info', `Error in shouldReplace : ${err.message}`)
+      log('info', `Error in shouldReplaceFile : ${err.message}`)
       shouldReplace = true
     }
   }


### PR DESCRIPTION
For the manifest lib, we recognized when we are in dev mode or production with
NODE_ENV env var. In the previous webpack version, this var was set to 'none'
Now, it is not set anymore