### PR TITLE
feat(saveFiles): forces file replace when missing carbonCopy or electronicSafe attribute in the existing file

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -492,6 +492,9 @@ const shouldReplaceFile = async function(file, entry, options) {
     throw new Error('BAD_DOWNLOADED_FILE')
   }
   const defaultShouldReplaceFile = (file, entry) => {
+    const shouldForceMetadataAttr = attr =>
+      !getAttribute(file, `metadata.${attr}`) &&
+      get(entry, `fileAttributes.metadata.${attr}`)
     // replace all files with meta if there is file metadata to add
     const fileHasNoMetadata = !getAttribute(file, 'metadata')
     const fileHasNoId = !getAttribute(file, 'metadata.fileIdAttributes')
@@ -507,7 +510,9 @@ const shouldReplaceFile = async function(file, entry, options) {
     const result =
       (fileHasNoMetadata && entryHasMetadata) ||
       (fileHasNoId && !!options.fileIdAttributes) ||
-      (hasSourceAccountIdentifierOption && !fileHasSourceAccountIdentifier)
+      (hasSourceAccountIdentifierOption && !fileHasSourceAccountIdentifier) ||
+      shouldForceMetadataAttr('carbonCopy') ||
+      shouldForceMetadataAttr('electronicSafe')
     return result
   }
   const shouldReplaceFileFn =

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
@@ -274,6 +274,40 @@ describe('saveFiles', function() {
       expect(cozyClient.files.create).not.toHaveBeenCalled()
     })
   })
+
+  describe('when new carbonCopy metadata available in entry', () => {
+    it('should update the file', async () => {
+      expect.assertions(2)
+      cozyClient.files.statByPath.mockImplementation(path => {
+        // Must check if we are stating on the folder or on the file
+        return path === FOLDER_PATH
+          ? asyncResolve({ _id: 'folderId' })
+          : asyncResolve(
+              makeFile('existingFileId', {
+                name: 'bill.pdf'
+              })
+            )
+      })
+      await saveFiles(
+        [
+          {
+            fileurl: 'https://coucou.com/filetodownload.pdf',
+            filename: 'bill.pdf',
+            fileAttributes: {
+              metadata: {
+                carbonCopy: true
+              }
+            }
+          }
+        ],
+        {
+          folderPath: 'mainPath'
+        }
+      )
+      expect(cozyClient.files.create).not.toHaveBeenCalled()
+      expect(cozyClient.files.updateById).toHaveBeenCalled()
+    })
+  })
 })
 
 describe('subPath handling', () => {


### PR DESCRIPTION
In saveFiles, when the connector sends document with carbonCopy or electronicSafe metadata attribute, if there is a corresponding existing file and if this file does not have these attributes yet. The file is replaced automatically.