### PR TITLE
fix: use es5 build of pdfjs

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -220,9 +220,9 @@ use this function.
 
 Parameters:
 
-* `documents`: an array of objects corresponding to the data you want to save in the cozy
-* `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
-* `options` (object): option object
+`documents`: an array of objects corresponding to the data you want to save in the cozy
+`doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
+`options` (object): option object
   + `sourceAccount` (String): id of the source account
   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
 
@@ -288,9 +288,9 @@ use this function.
 
 Parameters:
 
-* `documents`: an array of objects corresponding to the data you want to save in the cozy
-* `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
-* `options` :
+`documents`: an array of objects corresponding to the data you want to save in the cozy
+`doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
+`options` :
    - `keys` (array) : List of keys used to check that two items are the same. By default it is set to `['id']'.
    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
    - `selector` (optionnal object) : Mango request to get records. Default is built from the keys `{selector: {_id: {"$gt": null}}}` to get all the records.
@@ -513,9 +513,9 @@ manifest, to be able to use this function.
 
 Parameters:
 
-* `contact` (object): the identity to create/update as an object io.cozy.contacts
-* `accountIdentifier` (string): a string that represent the account use, if available fields.login
-* `options` (object): options which will be given to updateOrCreate directly :
+`contact` (object): the identity to create/update as an object io.cozy.contacts
+`accountIdentifier` (string): a string that represent the account use, if available fields.login
+`options` (object): options which will be given to updateOrCreate directly :
   + `sourceAccount` (String): id of the source account
   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
 
@@ -662,10 +662,10 @@ exist in the cozy or not
 You need the full permission for the given doctype in your manifest, to be able to
 use this function.
 
-* `entries` (object array): Documents to save
-* `doctype` (string): Doctype of the documents
-* `matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
-* `options` (object): general option affecting metadata :
+`entries` (object array): Documents to save
+`doctype` (string): Doctype of the documents
+`matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
+`options` (object): general option affecting metadata :
   + `sourceAccount` (String): id of the source account
   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
 
@@ -694,7 +694,7 @@ deprecated by the findAll method from cozyClient
 
 Parameters:
 
-* `doctype` (string): the doctype from which you want to fetch the data
+`doctype` (string): the doctype from which you want to fetch the data
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 <a name="module_utils..queryAll"></a>
@@ -706,9 +706,9 @@ with a selector and an index
 
 Parameters:
 
-* `doctype` (string): the doctype from which you want to fetch the data
-* `selector` (object): the mango query selector
-* `index` (object): (optional) the query selector index. If not defined, the function will
+`doctype` (string): the doctype from which you want to fetch the data
+`selector` (object): the mango query selector
+`index` (object): (optional) the query selector index. If not defined, the function will
 create it's own index with the keys specified in the selector
 
 
@@ -724,16 +724,16 @@ This function find duplicates in a given doctype, filtered by an optional mango 
 
 Parameters:
 
-* `doctype` (string): the doctype from which you want to fetch the data
-* `selector` (object): (optional) the mango query selector
-* `options` :
+`doctype` (string): the doctype from which you want to fetch the data
+`selector` (object): (optional) the mango query selector
+`options` :
    - `keys` (array) : List of keys used to check that two items are the same.
    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
 
 Returns an object with the following keys:
-* `toKeep`: this is the list of unique documents that you should keep in db
-* `toRemove`: this is the list of documents that can remove from db. If this is io.cozy.bills
+`toKeep`: this is the list of unique documents that you should keep in db
+`toRemove`: this is the list of documents that can remove from db. If this is io.cozy.bills
 documents, do not forget to clean linked bank operations
 
 ```javascript
@@ -748,10 +748,10 @@ This is a shortcut to update multiple documents in one call
 
 Parameters:
 
-* `doctype` (string): the doctype from which you want to fetch the data
-* `ids` (array): array of ids of documents to update
-* `transformation` (object): attributes to change with their values
-* `options` :
+`doctype` (string): the doctype from which you want to fetch the data
+`ids` (array): array of ids of documents to update
+`transformation` (object): attributes to change with their values
+`options` :
    - `keys` (array) : List of keys used to check that two items are the same.
    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
@@ -770,10 +770,10 @@ This is a shortcut to delete multiple documents in one call
 
 Parameters:
 
-* `doctype` (string): the doctype from which you want to fetch the data
-* `documents` (array): documents to delete with their ids
-* `transformation` (object): attributes to change with their values
-* `options` :
+`doctype` (string): the doctype from which you want to fetch the data
+`documents` (array): documents to delete with their ids
+`transformation` (object): attributes to change with their values
+`options` :
    - `keys` (array) : List of keys used to check that two items are the same.
    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
@@ -795,8 +795,8 @@ This function can read the content of a cozy pdf file and output its text
 
 Parameters:
 
-* `fileId` (string): the id of the file in the cozy
-* `options` :
+`fileId` (string): the id of the file in the cozy
+`options` :
    - `pages` (array or number) : The list of page you want to interpret
 
 
@@ -821,7 +821,7 @@ This function convert a Date Object to a ISO date string (2018-07-31)
 
 Parameters:
 
-* `date` (Date): the id of the file in the cozy
+`date` (Date): the id of the file in the cozy
 
 Returns a string
 
@@ -853,8 +853,8 @@ The global model is a model specific to hosted Cozy instances. It is not availab
 The local model is based on the user manual categorizations.
 
 Each model adds two properties to the transactions:
-  * The global model adds `cozyCategoryId` and `cozyCategoryProba`
-  * The local model adds `localCategoryId` and `localCategoryProba`
+  The global model adds `cozyCategoryId` and `cozyCategoryProba`
+  The local model adds `localCategoryId` and `localCategoryProba`
 
 In the end, each transaction can have up to four different categories. An application can use these categories to show the most significant for the user. See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bank.md#categories for more informations.
 

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -80,7 +80,7 @@
     "lerna": "3.22.1",
     "lerna-changelog": "1.0.1",
     "pdfjs": "2.4.3",
-    "pdfjs-dist": "2.6.347",
+    "pdfjs-dist": "2.7.570",
     "zombie": "6.1.4"
   }
 }

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -66,7 +66,6 @@ const checkTOS = err => {
  *
  * ⚠️  A promise should be returned from the `fetch` function otherwise
  * the konnector cannot know that asynchronous code has been called.
- *
  * @example
  * ```javascript
  * const { BaseKonnector } = require('cozy-konnector-libs')
@@ -303,9 +302,7 @@ class BaseKonnector {
    * @throws Will throw `USER_ACTION_NEEDED.TWOFA_EXPIRED` if the konnector job is not run manually (we assume that
    * not run manually means that we do not have a graphic interface to fill the required information)
    * @throws Will throw `USER_ACTION_NEEDED.TWOFA_EXPIRED` if 2FA is not filled by the user soon enough
-   *
    * @returns {Promise} Contains twoFa code entered by user
-   *
    * @example
    *
    * ```javascript
@@ -476,7 +473,6 @@ class BaseKonnector {
    * connector now
    *
    * @param  {string} err - The error code to be saved as connector result see [docs/ERROR_CODES.md]
-   *
    * @example
    * ```javascript
    * this.terminate('LOGIN_FAILED')

--- a/packages/cozy-konnector-libs/src/libs/CookieKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/CookieKonnector.js
@@ -14,7 +14,6 @@ const JAR_ACCOUNT_KEY = 'session'
  * to use the central cookie which can be saved/restored.
  * You need at least the `GET` and `PUT` permissions on `io.cozy.accounts` in your manifest to allow
  * it to save/restore cookies
- *
  * @example
  * ```javascript
  * const { CookieKonnector } = require('cozy-konnector-libs')
@@ -34,7 +33,6 @@ const JAR_ACCOUNT_KEY = 'session'
  * })
  * connector.run()
  * ```
- *
  */
 class CookieKonnector extends BaseKonnector {
   /**

--- a/packages/cozy-konnector-libs/src/libs/CozyBrowser.js
+++ b/packages/cozy-konnector-libs/src/libs/CozyBrowser.js
@@ -33,7 +33,6 @@ const Request = require('request')
  *
  * @param  {string} options.userAgent - The user agent string used by the browser
  * @returns {object} Zombie browser extended class
- *
  * @example
  *
  * ```javascript
@@ -41,7 +40,6 @@ const Request = require('request')
  * const browser = new Browser()
  * await browser.visit('http://quotes.toscrape.com/')
  * ```
- *
  * @alias module:CozyBrowser
  */
 const defaultOptions = {

--- a/packages/cozy-konnector-libs/src/libs/addData.js
+++ b/packages/cozy-konnector-libs/src/libs/addData.js
@@ -16,9 +16,9 @@ const { getCozyMetadata } = require('./manifest')
  *
  * Parameters:
  *
- * * `documents`: an array of objects corresponding to the data you want to save in the cozy
- * * `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
- * * `options` (object): option object
+ * `documents`: an array of objects corresponding to the data you want to save in the cozy
+ * `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
+ * `options` (object): option object
  *   + `sourceAccount` (String): id of the source account
  *   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
  *

--- a/packages/cozy-konnector-libs/src/libs/categorization/index.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/index.js
@@ -20,13 +20,12 @@ const log = logger.namespace('categorization')
  * The local model is based on the user manual categorizations.
  *
  * Each model adds two properties to the transactions:
- *   * The global model adds `cozyCategoryId` and `cozyCategoryProba`
- *   * The local model adds `localCategoryId` and `localCategoryProba`
+ *   The global model adds `cozyCategoryId` and `cozyCategoryProba`
+ *   The local model adds `localCategoryId` and `localCategoryProba`
  *
  * In the end, each transaction can have up to four different categories. An application can use these categories to show the most significant for the user. See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bank.md#categories for more informations.
  *
  * @returns {object} an object with a `categorize` method
- *
  * @example
  * const { BaseKonnector, createCategorizer } = require('cozy-konnector-libs')
  *
@@ -76,9 +75,7 @@ async function createCategorizer() {
  * Initialize global and local models and categorize the given array of transactions
  *
  * @see {@link createCategorizer} for more informations about models initialization
- *
  * @returns {object[]} the categorized transactions
- *
  * @example
  * const { BaseKonnector, categorize } = require('cozy-konnector-libs')
  *

--- a/packages/cozy-konnector-libs/src/libs/hydrateAndFilter.js
+++ b/packages/cozy-konnector-libs/src/libs/hydrateAndFilter.js
@@ -41,9 +41,9 @@ const suitableCall = (funcOrMethod, ...args) => {
  *
  * Parameters:
  *
- * * `documents`: an array of objects corresponding to the data you want to save in the cozy
- * * `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
- * * `options` :
+ * `documents`: an array of objects corresponding to the data you want to save in the cozy
+ * `doctype` (string): the doctype where you want to save data (ex: 'io.cozy.bills')
+ * `options` :
  *    - `keys` (array) : List of keys used to check that two items are the same. By default it is set to `['id']'.
  *    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
  *    - `selector` (optionnal object) : Mango request to get records. Default is built from the keys `{selector: {_id: {"$gt": null}}}` to get all the records.

--- a/packages/cozy-konnector-libs/src/libs/request/request.js
+++ b/packages/cozy-konnector-libs/src/libs/request/request.js
@@ -40,14 +40,14 @@
  * })
  * ```
  * - `debug`: will display request and responses details in error output. Possible values :
- *   * true : display request and response in normal request-debug json format
- *   * 'json' : display request and response in full json format
- *   * 'simple' : display main information about each request and response
+ *   true : display request and response in normal request-debug json format
+ *   'json' : display request and response in full json format
+ *   'simple' : display main information about each request and response
  *   ```
  *   GET -> http://books.toscrape.com/media/cache/26/0c/260c6ae16bce31c8f8c95daddd9f4a1c.jpg
  *   <- 200  Content-Length: 7095
  *   ```
- *   * 'full' : display comple information about each request and response
+ *   'full' : display comple information about each request and response
  *   ```
  *   GET -> http://quotes.toscrape.com/login
  *

--- a/packages/cozy-konnector-libs/src/libs/saveBills.js
+++ b/packages/cozy-konnector-libs/src/libs/saveBills.js
@@ -62,7 +62,6 @@ const requiredAttributes = {
  *   })
  * })
  * ```
- *
  * @alias module:saveBills
  */
 const saveBills = async (inputEntries, fields, inputOptions = {}) => {

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -50,14 +50,12 @@ const DEFAULT_RETRY = 1 // do not retry by default
  * @param {Array} options.fileIdAttributes - array of strings : Describes which attributes of files will be taken as primary key for files to check if they already exist, even if they are moved. If not given, the file path will used for deduplication as before.
  * @param {string} options.subPath - A subpath to save this file, will be created if needed.
  * @param {Function} options.fetchFile - the connector can give it's own function to fetch the file from the website, which will be run only when necessary (if the corresponding file is missing on the cozy) function returning the stream). This function must return a promise resolved as a stream
- *
  * @example
  * ```javascript
  * await saveFiles([{fileurl: 'https://...', filename: 'bill1.pdf'}], fields, {
  *    fileIdAttributes: ['fileurl']
  * })
  * ```
- *
  * @alias module:saveFiles
  */
 const saveFiles = async (entries, fields, options = {}) => {

--- a/packages/cozy-konnector-libs/src/libs/saveIdentity.js
+++ b/packages/cozy-konnector-libs/src/libs/saveIdentity.js
@@ -16,9 +16,9 @@ const updateOrCreate = require('./updateOrCreate')
  *
  * Parameters:
  *
- * * `contact` (object): the identity to create/update as an object io.cozy.contacts
- * * `accountIdentifier` (string): a string that represent the account use, if available fields.login
- * * `options` (object): options which will be given to updateOrCreate directly :
+ * `contact` (object): the identity to create/update as an object io.cozy.contacts
+ * `accountIdentifier` (string): a string that represent the account use, if available fields.login
+ * `options` (object): options which will be given to updateOrCreate directly :
  *   + `sourceAccount` (String): id of the source account
  *   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
  *

--- a/packages/cozy-konnector-libs/src/libs/signin.js
+++ b/packages/cozy-konnector-libs/src/libs/signin.js
@@ -63,7 +63,6 @@ const cheerio = require('cheerio')
  *  - detect if the credentials work or not -> LOGIN_FAILED
  *  - detect if actions from the user are needed -> USER_ACTION_NEEDED
  *  - detect if the targeted website is out -> VENDOR_DOWN
- *
  * @example
  * ```javascript
  * const $ = signin({
@@ -81,7 +80,6 @@ const cheerio = require('cheerio')
  * Do not forget that the use of the signin function is not mandatory in a connector and won't work
  * if the signin page does not use html forms. Here, a simple POST request may be a lot more
  * simple.
- *
  * @alias module:signin
  */
 function signin({

--- a/packages/cozy-konnector-libs/src/libs/solveCaptcha.js
+++ b/packages/cozy-konnector-libs/src/libs/solveCaptcha.js
@@ -44,7 +44,6 @@ const DEFAULT_TIMEOUT = connectorStartTime + 3 * m // 3 minutes by default to le
  * })
  * // now use the solveKey to submit your form
  * ```
- *
  * @alias module:solveCaptcha
  */
 const solveCaptcha = async (params = {}) => {

--- a/packages/cozy-konnector-libs/src/libs/updateOrCreate.js
+++ b/packages/cozy-konnector-libs/src/libs/updateOrCreate.js
@@ -17,10 +17,10 @@ const { getCozyMetadata } = require('./manifest')
  * You need the full permission for the given doctype in your manifest, to be able to
  * use this function.
  *
- * * `entries` (object array): Documents to save
- * * `doctype` (string): Doctype of the documents
- * * `matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
- * * `options` (object): general option affecting metadata :
+ * `entries` (object array): Documents to save
+ * `doctype` (string): Doctype of the documents
+ * `matchingAttributes` (string array): attributes in each entry used to check if an entry already exists in the Cozy
+ * `options` (object): general option affecting metadata :
  *   + `sourceAccount` (String): id of the source account
  *   + `sourceAccountIdentifier` (String): identifier unique to the account targetted by the connector. It is the login most of the time
  *

--- a/packages/cozy-konnector-libs/src/libs/utils.js
+++ b/packages/cozy-konnector-libs/src/libs/utils.js
@@ -17,7 +17,7 @@ const { format } = require('date-fns')
  *
  * Parameters:
  *
- * * `doctype` (string): the doctype from which you want to fetch the data
+ * `doctype` (string): the doctype from which you want to fetch the data
  *
  */
 const fetchAll = async doctype => {
@@ -31,9 +31,9 @@ const fetchAll = async doctype => {
  *
  * Parameters:
  *
- * * `doctype` (string): the doctype from which you want to fetch the data
- * * `selector` (object): the mango query selector
- * * `index` (object): (optional) the query selector index. If not defined, the function will
+ * `doctype` (string): the doctype from which you want to fetch the data
+ * `selector` (object): the mango query selector
+ * `index` (object): (optional) the query selector index. If not defined, the function will
  * create it's own index with the keys specified in the selector
  *
  *
@@ -69,16 +69,16 @@ const queryAll = async (doctype, selector, index) => {
  *
  * Parameters:
  *
- * * `doctype` (string): the doctype from which you want to fetch the data
- * * `selector` (object): (optional) the mango query selector
- * * `options` :
+ * `doctype` (string): the doctype from which you want to fetch the data
+ * `selector` (object): (optional) the mango query selector
+ * `options` :
  *    - `keys` (array) : List of keys used to check that two items are the same.
  *    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
  *    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
  *
  * Returns an object with the following keys:
- * * `toKeep`: this is the list of unique documents that you should keep in db
- * * `toRemove`: this is the list of documents that can remove from db. If this is io.cozy.bills
+ * `toKeep`: this is the list of unique documents that you should keep in db
+ * `toRemove`: this is the list of documents that can remove from db. If this is io.cozy.bills
  * documents, do not forget to clean linked bank operations
  *
  * ```javascript
@@ -151,10 +151,10 @@ const sortBillsByLinkedOperationNumber = (bills, operations) => {
  *
  * Parameters:
  *
- * * `doctype` (string): the doctype from which you want to fetch the data
- * * `ids` (array): array of ids of documents to update
- * * `transformation` (object): attributes to change with their values
- * * `options` :
+ * `doctype` (string): the doctype from which you want to fetch the data
+ * `ids` (array): array of ids of documents to update
+ * `transformation` (object): attributes to change with their values
+ * `options` :
  *    - `keys` (array) : List of keys used to check that two items are the same.
  *    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
  *    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
@@ -183,10 +183,10 @@ const batchUpdateAttributes = async (doctype, ids, transformation) => {
  *
  * Parameters:
  *
- * * `doctype` (string): the doctype from which you want to fetch the data
- * * `documents` (array): documents to delete with their ids
- * * `transformation` (object): attributes to change with their values
- * * `options` :
+ * `doctype` (string): the doctype from which you want to fetch the data
+ * `documents` (array): documents to delete with their ids
+ * `transformation` (object): attributes to change with their values
+ * `options` :
  *    - `keys` (array) : List of keys used to check that two items are the same.
  *    - `index` (optionnal) : Return value returned by `cozy.data.defineIndex`, the default will correspond to all documents of the selected doctype.
  *    - `selector` (optionnal object) : Mango request to get records. Gets all the records by default
@@ -214,8 +214,8 @@ const batchDelete = async (doctype, documents) => {
  *
  * Parameters:
  *
- * * `fileId` (string): the id of the file in the cozy
- * * `options` :
+ * `fileId` (string): the id of the file in the cozy
+ * `options` :
  *    - `pages` (array or number) : The list of page you want to interpret
  *
  *
@@ -235,7 +235,7 @@ const batchDelete = async (doctype, documents) => {
 const getPdfText = async (fileId, options = {}) => {
   let pdfjs
   try {
-    pdfjs = require('pdfjs-dist')
+    pdfjs = require('pdfjs-dist/es5/build/pdf')
   } catch (err) {
     throw new Error(
       'pdfjs-dist dependency is missing. Please add it in your package.json'
@@ -276,7 +276,7 @@ module.exports = {
  *
  * Parameters:
  *
- * * `date` (Date): the id of the file in the cozy
+ * `date` (Date): the id of the file in the cozy
  *
  * Returns a string
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -9596,10 +9596,10 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pdfjs-dist@2.6.347:
-  version "2.6.347"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.6.347.tgz#f257ed66e83be900cd0fd28524a2187fb9e25cd5"
-  integrity sha512-QC+h7hG2su9v/nU1wEI3SnpPIrqJODL7GTDFvR74ANKGq1AFJW16PH8VWnhpiTi9YcLSFV9xLeWSgq+ckHLdVQ==
+pdfjs-dist@2.7.570:
+  version "2.7.570"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.7.570.tgz#7233241a2437ac22387656099b6e549d032f0b35"
+  integrity sha512-/ZkA1FwkEOyDaq11JhMLazdwQAA0F9uwrP7h/1L9Akt9KWh1G5/tkzS+bPuUELq2s2GDFnaT+kooN/aSjT7DXQ==
 
 pdfjs@2.4.3:
   version "2.4.3"


### PR DESCRIPTION
This fixes some errors with new version of pdfjs

Error: was "The browser/environment lacks native support for critical functionality used by the PDF.js library (e.g. `ReadableStream` and/or `Promise.allSettled`); please use an ES5-compatible build instead."

Source for the fix : https://stackoverflow.com/questions/64189359/reading-pdf-from-url-with-node-js-using-pdf-js