### PR TITLE
fix: Add argparse as dependency

### DIFF
--- a/packages/cozy-jobs-cli/package.json
+++ b/packages/cozy-jobs-cli/package.json
@@ -20,6 +20,7 @@
     "@pollyjs/adapter-node-http": "5.1.1",
     "@pollyjs/core": "5.1.1",
     "@pollyjs/persister-fs": "5.1.1",
+    "argparse": "^2.0.1",
     "babel-runtime": "6.26.0",
     "btoa": "^1.2.1",
     "cheerio": "1.0.0-rc.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,11 @@ argparse@^1.0.10, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 argsarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"


### PR DESCRIPTION
cozy-konnector-dev was failing when installed globally because argparse
was missing.