### PR TITLE
Fix local categorization

### DIFF
--- a/packages/cozy-konnector-libs/src/index.js
+++ b/packages/cozy-konnector-libs/src/index.js
@@ -1,7 +1,7 @@
-const log = require('cozy-logger').namespace('cozy-konnector-libs')
 const requestFactory = require('./libs/request')
 const hydrateAndFilter = require('./libs/hydrateAndFilter')
 const categorization = require('./libs/categorization')
+const log = require('./libs/log')
 
 module.exports = {
   BaseKonnector: require('./libs/BaseKonnector'),

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -177,7 +177,9 @@ class BaseKonnector {
     this.parameters = cozyParameters
 
     // Set account
-    const account = await this.getAccount(cozyFields.account)
+    const account = cozyFields.account
+      ? await this.getAccount(cozyFields.account)
+      : {}
     if (!account || !account._id) {
       log('warn', 'No account was retrieved from getAccount')
     }

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/parameters.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/parameters.js
@@ -1,11 +1,21 @@
-const { BankTransaction } = require('cozy-doctypes')
+const cozyClient = require('../../cozyclient')
+const { Q } = require('cozy-client')
 
 async function fetchTransactionsWithManualCat() {
-  const transactionsWithManualCat = await BankTransaction.queryAll({
-    manualCategoryId: { $exists: true }
-  })
+  const client = cozyClient.new
 
-  return transactionsWithManualCat
+  const query = Q('io.cozy.bank.operations')
+    .where({
+      manualCategoryId: { $gt: null }
+    })
+    .partialIndex({
+      manualCategoryId: {
+        $exists: true
+      }
+    })
+    .indexFields(['manualCategoryId'])
+
+  return client.queryAll(query)
 }
 
 module.exports = {

--- a/packages/cozy-konnector-libs/src/libs/log.js
+++ b/packages/cozy-konnector-libs/src/libs/log.js
@@ -1,0 +1,3 @@
+const log = require('cozy-logger').namespace('cozy-konnector-libs')
+
+module.exports = log


### PR DESCRIPTION
When running the local categorization, we query all transactions having a manual category set. This was done in a suboptimal way, making the query very slow.
I also suspect https://github.com/konnectors/libs/commit/e8d1d9a5002a4305dffb361f3c36a2e97a83e8f7 to have potential some side-effects, with uninitialized cozy-client-js. 