### PR TITLE
fix: Regression in BaseKonnector unit test

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
@@ -47,6 +47,7 @@ describe('finding folder path', () => {
 describe('run', () => {
   const envFields = {
     COZY_FIELDS: JSON.stringify({
+      account: 'testaccount',
       COZY_URL: 'http://cozy.tools:8080',
       fields: {
         login: 'mylogin',


### PR DESCRIPTION
Now COZY_FIELDS needs an "account" attributes to have proper
fields in the BaseKonnector, which is normal after all

This fixes unit test regression introduced in https://github.com/konnectors/libs/pull/816
