### PR TITLE
feat: Make peer dependencies optional

### DIFF
--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -47,6 +47,17 @@
     "pdfjs-dist": "^2.1.266",
     "zombie": "^6.1.4"
   },
+  "peerDependenciesMeta": {
+    "pdfjs": {
+      "optional": true
+    },
+    "pdfjs-dist": {
+      "optional": true
+    },
+    "zombie": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "npm run transpile",
     "transpile": "rm -rf dist/* ; babel src --out-dir dist",


### PR DESCRIPTION
Using the peerDependenciesMeta option
https://classic.yarnpkg.com/en/docs/package-json#peerdependenciesmeta-

This will avoid errors like :
not found: Error: Can't resolve 'pdfjs'
when building the connectors which do not use these packages
