### PR TITLE
fix: Upgrade qualification when metadata already present

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -515,7 +515,7 @@ const shouldReplaceFile = async function(file, entry, options) {
       (hasSourceAccountIdentifierOption && !fileHasSourceAccountIdentifier) ||
       shouldForceMetadataAttr('carbonCopy') ||
       shouldForceMetadataAttr('electronicSafe') ||
-      shouldForceMetadataAttr('categories')
+      shouldForceMetadataAttr('qualification')
 
     if (result) {
       if (fileHasNoMetadata && entryHasMetadata)

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.spec.js
@@ -308,6 +308,47 @@ describe('saveFiles', function() {
       expect(cozyClient.files.updateById).toHaveBeenCalled()
     })
   })
+
+  describe('when new qualification V2 is available', () => {
+    it('should update the file', async () => {
+      expect.assertions(2)
+      cozyClient.files.statByPath.mockImplementation(path => {
+        // Must check if we are stating on the folder or on the file
+        return path === FOLDER_PATH
+          ? asyncResolve({ _id: 'folderId' })
+          : asyncResolve(
+              makeFile('existingFileId', {
+                name: 'bill.pdf',
+                metadata: {
+                  carbonCopy: true
+                }
+              })
+            )
+      })
+      await saveFiles(
+        [
+          {
+            fileurl: 'https://coucou.com/filetodownload.pdf',
+            filename: 'bill.pdf',
+            fileAttributes: {
+              metadata: {
+                carbonCopy: true,
+                qualification: {
+                  item1: true,
+                  item2: 'toto'
+                }
+              }
+            }
+          }
+        ],
+        {
+          folderPath: 'mainPath'
+        }
+      )
+      expect(cozyClient.files.create).not.toHaveBeenCalled()
+      expect(cozyClient.files.updateById).toHaveBeenCalled()
+    })
+  })
 })
 
 describe('subPath handling', () => {


### PR DESCRIPTION
Qualification V2 is not updated on existing file if some metadata are already present. (For example carbon_copy)
Will be with this PR.
A test has been added.

A remaining question is, do we want to do the same when all metadata attributes.