### PR TITLE
feat: Allow file qualification to work in standalone mode

### DIFF
--- a/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
+++ b/packages/cozy-konnector-libs/src/helpers/cozy-client-js-stub.js
@@ -10,6 +10,11 @@ const rawBody = require('raw-body')
 const stripJsonComments = require('strip-json-comments')
 const manifest = require('../libs/manifest')
 const sleep = require('util').promisify(global.setTimeout)
+const { models } = require('cozy-client')
+
+const newCozyClient = {
+  models
+}
 
 const rootPath = JSON.parse(
   process.env.COZY_FIELDS || '{"folder_to_save": "."}'
@@ -26,6 +31,7 @@ function setDefaults(doctype) {
 }
 
 module.exports = {
+  new: newCozyClient,
   _setDb(newDb) {
     db = newDb
   },


### PR DESCRIPTION
This only fixes file qualification (which uses cozy-client) in standalone mode.

There is still a lot to do to have a proper cozy-client stub