### PR TITLE
feat: Allow saveIdentity to handle full identtity and not only contacts

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -540,10 +540,9 @@ Set or merge a io.cozy.identities
 
 You need full permission for the doctype io.cozy.identities in your
 manifest, to be able to use this function.
-
 Parameters:
 
-`contact` (object): the identity to create/update as an object io.cozy.contacts
+`identity` (object): the identity to create/update as an io.cozy.identities object
 `accountIdentifier` (string): a string that represent the account use, if available fields.login
 `options` (object): options which will be given to updateOrCreate directly :
   + `sourceAccount` (String): id of the source account
@@ -554,8 +553,10 @@ Parameters:
 const { saveIdentity } = require('cozy-konnector-libs')
 const identity =
   {
-    name: 'toto',
-    email: { 'address': 'toto@example.com' }
+    contact: {
+      name: 'toto',
+      email: { 'address': 'toto@example.com' }
+    }
   }
 
 return saveIdentity(identity, fields.login)

--- a/packages/cozy-konnector-libs/src/libs/saveIdentity.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveIdentity.spec.js
@@ -1,0 +1,43 @@
+jest.mock('./updateOrCreate')
+const updateOrCreate = require('./updateOrCreate')
+const saveIdentity = require('./saveIdentity')
+
+describe('saveIdentity', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should updateOrCreate a full identity with given identifier', async () => {
+    await saveIdentity(
+      { contact: { name: 'test' }, tax_information: { aj: 20 } },
+      'myidentifier'
+    )
+    expect(updateOrCreate).toHaveBeenCalledWith(
+      [
+        {
+          contact: { name: 'test' },
+          tax_information: { aj: 20 },
+          identifier: 'myidentifier'
+        }
+      ],
+      'io.cozy.identities',
+      ['identifier', 'cozyMetadata.createdByApp'],
+      { sourceAccountIdentifier: 'myidentifier' }
+    )
+  })
+
+  it('should updateOrCreate a full identity with given contact (for retro compatibility)', async () => {
+    await saveIdentity({ name: 'test' }, 'myidentifier')
+    expect(updateOrCreate).toHaveBeenCalledWith(
+      [
+        {
+          contact: { name: 'test' },
+          identifier: 'myidentifier'
+        }
+      ],
+      'io.cozy.identities',
+      ['identifier', 'cozyMetadata.createdByApp'],
+      { sourceAccountIdentifier: 'myidentifier' }
+    )
+  })
+})


### PR DESCRIPTION
To not change the signature of the function completely, we check if the
first parameter contains a "contact", if not, the object will be wrapped
in a full identity object ({contact: param}.

With this, we suppose that all the identities will contain at least some
contact information which, I suppose is a safe asumption.

I also added some unit test to show the difference.