### PR TITLE
feat: Create categorizer options

### DIFF
--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -869,13 +869,13 @@ Bank transactions categorization
 
 
 * [categorization](#module_categorization)
-    * [~createCategorizer(options)](#module_categorization..createCategorizer) ⇒ <code>object</code>
+    * [~createCategorizer(options)](#module_categorization..createCategorizer) ⇒ <code>Object</code>
     * [~categorize(transactions, options)](#module_categorization..categorize) ⇒ <code>Array.&lt;object&gt;</code>
     * [~CreateCategorizerOptions](#module_categorization..CreateCategorizerOptions)
 
 <a name="module_categorization..createCategorizer"></a>
 
-### categorization~createCategorizer(options) ⇒ <code>object</code>
+### categorization~createCategorizer(options) ⇒ <code>Object</code>
 Initialize global and local models and return an object exposing a
 `categorize` function that applies both models on an array of transactions
 
@@ -890,7 +890,7 @@ Each model adds two properties to the transactions:
 In the end, each transaction can have up to four different categories. An application can use these categories to show the most significant for the user. See https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bank.md#categories for more informations.
 
 **Kind**: inner method of [<code>categorization</code>](#module_categorization)  
-**Returns**: <code>object</code> - an object with a `categorize` method  
+**Returns**: <code>Object</code> - A method to categorize transactions and the classifiers it uses.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -946,7 +946,8 @@ class BankingKonnector extends BaseKonnector {
 | Name | Type | Description |
 | --- | --- | --- |
 | useGlobalModel | <code>boolean</code> | Whether to use the globally trained model |
-| fetchTransactions | <code>function</code> | A custom training transaction fetcher |
+| customTransactionFetcher | <code>function</code> | A custom training transaction fetcher |
+| pretrainedClassifier | <code>object</code> | A pretrained instance of a bayes classifier |
 
 <a name="BaseKonnector"></a>
 

--- a/packages/cozy-konnector-libs/docs/api.md
+++ b/packages/cozy-konnector-libs/docs/api.md
@@ -869,12 +869,13 @@ Bank transactions categorization
 
 
 * [categorization](#module_categorization)
-    * [~createCategorizer()](#module_categorization..createCategorizer) ⇒ <code>object</code>
-    * [~categorize()](#module_categorization..categorize) ⇒ <code>Array.&lt;object&gt;</code>
+    * [~createCategorizer(options)](#module_categorization..createCategorizer) ⇒ <code>object</code>
+    * [~categorize(transactions, options)](#module_categorization..categorize) ⇒ <code>Array.&lt;object&gt;</code>
+    * [~CreateCategorizerOptions](#module_categorization..CreateCategorizerOptions)
 
 <a name="module_categorization..createCategorizer"></a>
 
-### categorization~createCategorizer() ⇒ <code>object</code>
+### categorization~createCategorizer(options) ⇒ <code>object</code>
 Initialize global and local models and return an object exposing a
 `categorize` function that applies both models on an array of transactions
 
@@ -890,6 +891,11 @@ In the end, each transaction can have up to four different categories. An applic
 
 **Kind**: inner method of [<code>categorization</code>](#module_categorization)  
 **Returns**: <code>object</code> - an object with a `categorize` method  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>CreateCategorizerOptions</code> | Options used to build the categorizer |
+
 **Example**  
 ```js
 const { BaseKonnector, createCategorizer } = require('cozy-konnector-libs')
@@ -906,12 +912,18 @@ class BankingKonnector extends BaseKonnector {
 ```
 <a name="module_categorization..categorize"></a>
 
-### categorization~categorize() ⇒ <code>Array.&lt;object&gt;</code>
+### categorization~categorize(transactions, options) ⇒ <code>Array.&lt;object&gt;</code>
 Initialize global and local models and categorize the given array of transactions
 
 **Kind**: inner method of [<code>categorization</code>](#module_categorization)  
 **Returns**: <code>Array.&lt;object&gt;</code> - the categorized transactions  
 **See**: [createCategorizer](createCategorizer) for more informations about models initialization  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| transactions | <code>Array.&lt;object&gt;</code> | The transactions to categorize |
+| options | <code>CreateCategorizerOptions</code> | Options passed to create the categorizer |
+
 **Example**  
 ```js
 const { BaseKonnector, categorize } = require('cozy-konnector-libs')
@@ -925,6 +937,17 @@ class BankingKonnector extends BaseKonnector {
   }
 }
 ```
+<a name="module_categorization..CreateCategorizerOptions"></a>
+
+### categorization~CreateCategorizerOptions
+**Kind**: inner typedef of [<code>categorization</code>](#module_categorization)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| useGlobalModel | <code>boolean</code> | Whether to use the globally trained model |
+| fetchTransactions | <code>function</code> | A custom training transaction fetcher |
+
 <a name="BaseKonnector"></a>
 
 ## BaseKonnector

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -59,7 +59,7 @@
     }
   },
   "scripts": {
-    "build": "npm run transpile",
+    "build": "yarn run transpile",
     "transpile": "rm -rf dist/* ; babel src --out-dir dist",
     "prepublishOnly": "yarn run transpile",
     "test": "cross-env LOG_LEVEL=info jest ./src",

--- a/packages/cozy-konnector-libs/src/libs/categorization/globalModel/model.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/globalModel/model.js
@@ -35,7 +35,7 @@ async function createModel(options) {
     return transactions
   }
 
-  return { categorize }
+  return { categorize, classifier }
 }
 
 module.exports = {

--- a/packages/cozy-konnector-libs/src/libs/categorization/index.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/index.js
@@ -13,8 +13,8 @@ const log = logger.namespace('categorization')
 
 /**
  * @typedef CreateCategorizerOptions
- * @property {boolean} useGlobalModel
- * @property {Function} fetchTransactions
+ * @property {boolean} useGlobalModel Whether to use the globally trained model
+ * @property {Function} fetchTransactions A custom training transaction fetcher
  */
 
 /**
@@ -46,7 +46,8 @@ const log = logger.namespace('categorization')
  *   }
  * }
  */
-async function createCategorizer({ useGlobalModel = true, fetchTransactions }) {
+async function createCategorizer(options = {}) {
+  const { useGlobalModel = true, fetchTransactions } = options
   const classifierOptions = { tokenizer }
 
   // We can't initialize the model in parallel using `Promise.all` because with
@@ -87,6 +88,7 @@ async function createCategorizer({ useGlobalModel = true, fetchTransactions }) {
  * Initialize global and local models and categorize the given array of transactions
  *
  * @see {@link createCategorizer} for more informations about models initialization
+ * @param {object[]} transactions The transactions to categorize
  * @param {CreateCategorizerOptions} options Options passed to create the categorizer
  * @returns {object[]} the categorized transactions
  * @example

--- a/packages/cozy-konnector-libs/src/libs/categorization/index.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/index.js
@@ -59,24 +59,24 @@ async function createCategorizer(options) {
   // it is not possible to manage errors separately
   let globalModel, localModel
 
-  try {
-    globalModel = await createGlobalModel(classifierOptions)
-  } catch (e) {
-    log('warn', 'Failed to create global model:')
-    log('warn', e.message)
-  }
-
   if (useGlobalModel) {
     try {
-      localModel = await createLocalModel({
-        ...classifierOptions,
-        pretrainedClassifier,
-        customTransactionFetcher
-      })
+      globalModel = await createGlobalModel(classifierOptions)
     } catch (e) {
-      log('warn', 'Failed to create local model:')
+      log('warn', 'Failed to create global model:')
       log('warn', e.message)
     }
+  }
+
+  try {
+    localModel = await createLocalModel({
+      ...classifierOptions,
+      pretrainedClassifier,
+      customTransactionFetcher
+    })
+  } catch (e) {
+    log('warn', 'Failed to create local model:')
+    log('warn', e.message)
   }
 
   const modelsToApply = [globalModel, localModel].filter(Boolean)

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -81,13 +81,13 @@ const createLocalClassifier = (
 ) => {
   if (transactionsToLearn.length === 0) {
     throw new Error(
-      'Impossible to instanciate a classifier since there is no manually categorized transactions to learn from'
+      'Impossible to instanciate a classifier since there is no transactions to learn from'
     )
   }
 
   const classifier = bayes(initializationOptions)
 
-  log('debug', 'Learning from manually categorized transactions')
+  log('debug', 'Learning from categorized transactions')
   for (const transaction of transactionsToLearn) {
     classifier.learn(
       getLabelWithTags(transaction),
@@ -157,10 +157,7 @@ const createClassifier = async options => {
     transactions = await customTransactionFetcher()
   }
 
-  log(
-    'debug',
-    `Fetched ${transactions.length} manually categorized transactions`
-  )
+  log('debug', `Fetched ${transactions.length} transactions`)
 
   log('debug', 'Instanciating a new classifier')
 

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -146,8 +146,16 @@ const reweightModel = classifier => {
 }
 
 const createClassifier = async options => {
-  log('debug', 'Fetching manually categorized transactions')
-  const transactionsWithManualCat = await fetchTransactionsWithManualCat()
+  const { fetchTransactions, ...remainingOptions } = options
+
+  let transactionsWithManualCat = []
+  if (!fetchTransactions) {
+    log('debug', 'Fetching manually categorized transactions')
+    transactionsWithManualCat = await fetchTransactionsWithManualCat()
+  } else {
+    log('debug', 'Fetching categorized transactions')
+    transactionsWithManualCat = await fetchTransactions()
+  }
 
   log(
     'debug',
@@ -159,7 +167,7 @@ const createClassifier = async options => {
   const classifierOptions = getClassifierOptions(transactionsWithManualCat)
   const classifier = createLocalClassifier(
     transactionsWithManualCat,
-    { ...options, ...classifierOptions.initialization },
+    { ...remainingOptions, ...classifierOptions.initialization },
     classifierOptions.configuration
   )
 

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -146,27 +146,27 @@ const reweightModel = classifier => {
 }
 
 const createClassifier = async options => {
-  const { fetchTransactions, ...remainingOptions } = options
+  const { customTransactionFetcher, ...remainingOptions } = options
 
-  let transactionsWithManualCat = []
-  if (!fetchTransactions) {
+  let transactions = []
+  if (!customTransactionFetcher) {
     log('debug', 'Fetching manually categorized transactions')
-    transactionsWithManualCat = await fetchTransactionsWithManualCat()
+    transactions = await fetchTransactionsWithManualCat()
   } else {
     log('debug', 'Fetching categorized transactions')
-    transactionsWithManualCat = await fetchTransactions()
+    transactions = await customTransactionFetcher()
   }
 
   log(
     'debug',
-    `Fetched ${transactionsWithManualCat.length} manually categorized transactions`
+    `Fetched ${transactions.length} manually categorized transactions`
   )
 
   log('debug', 'Instanciating a new classifier')
 
-  const classifierOptions = getClassifierOptions(transactionsWithManualCat)
+  const classifierOptions = getClassifierOptions(transactions)
   const classifier = createLocalClassifier(
-    transactionsWithManualCat,
+    transactions,
     { ...remainingOptions, ...classifierOptions.initialization },
     classifierOptions.configuration
   )

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/model.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/model.js
@@ -19,7 +19,7 @@ async function createModel(options) {
     log('debug', 'Using a pretrained classifier')
     classifier = pretrainedClassifier
   } else {
-    log('debug', 'Create a new classifier')
+    log('debug', 'Create a new local classifier')
     classifier = await createClassifier(remainingOptions)
   }
 

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/model.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/model.js
@@ -12,8 +12,16 @@ const {
 const log = logger.namespace('categorization/localModel/model')
 
 async function createModel(options) {
-  log('debug', 'Create a new classifier')
-  const classifier = await createClassifier(options)
+  const { pretrainedClassifier, ...remainingOptions } = options
+
+  let classifier
+  if (pretrainedClassifier) {
+    log('debug', 'Using a pretrained classifier')
+    classifier = pretrainedClassifier
+  } else {
+    log('debug', 'Create a new classifier')
+    classifier = await createClassifier(remainingOptions)
+  }
 
   const vocabulary = Object.keys(classifier.vocabulary)
 
@@ -48,7 +56,7 @@ async function createModel(options) {
     }
   }
 
-  return { categorize }
+  return { categorize, classifier }
 }
 
 module.exports = {


### PR DESCRIPTION
Adds optional parameters to create a categorizer:

- `useGlobalModel` is a boolean which indicates whether to use the global model or not. It prevents depending on the remote asset storing the global model.
- `fetchTransactions` is a function that asynchronously returns an array of transactions, instead of fetching all manually labelled transactions.