### PR TITLE
fix: Renovate rule for cozy packages

### DIFF
--- a/packages/renovate-config-cozy-konnector/package.json
+++ b/packages/renovate-config-cozy-konnector/package.json
@@ -19,8 +19,8 @@
           ],
           "timezone": "Europe/Paris",
           "schedule": [
-            "after 8pm every weekday",
-            "before 7am every weekday",
+            "every weekday after 08:00 pm",
+            "every weekday before 07:00 am",
             "every weekend"
           ],
           "automerge": true,


### PR DESCRIPTION
'after 8pm every weekday' was not recognized by renovate
