### PR TITLE
fix: Init cozy-client-js instance from stack env

### DIFF
--- a/packages/cozy-jobs-cli/src/konnector-dev.js
+++ b/packages/cozy-jobs-cli/src/konnector-dev.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 /* eslint no-console: off */
 
-process.env.NODE_ENV = 'development'
-
 const config = require('./init-konnector-config')()
 const injectDevAccount = require('./inject-dev-account')
 const ArgumentParser = require('argparse').ArgumentParser

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -15,7 +15,7 @@ global.Headers = globalFetch.Headers
 // fixes an import problem of isomorphic fetch in cozy-client and cozy-client-js
 const manifest = require('./manifest')
 
-const getCozyClient = function (environment = 'production') {
+const getCozyClient = function(environment = 'production') {
   if (environment === 'standalone' || environment === 'test') {
     return require('../helpers/cozy-client-js-stub')
   }
@@ -77,7 +77,7 @@ function cozyClientJsFromEnv(cozyURL) {
   const cozyClient = new Client(options)
 
   if (jsonCredentials) {
-    jsonCredentials.token.toAuthHeader = function () {
+    jsonCredentials.token.toAuthHeader = function() {
       return 'Bearer ' + jsonCredentials.client.registrationAccessToken
     }
     cozyClient.saveCredentials(
@@ -85,6 +85,8 @@ function cozyClientJsFromEnv(cozyURL) {
       jsonCredentials.token
     )
   }
+
+  return cozyClient
 }
 
 module.exports = cozyClient

--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -4,7 +4,6 @@
  *
  * @module cozyClient
  */
-
 /* eslint no-console: off */
 
 const { Client, MemoryStorage } = require('cozy-client-js')
@@ -31,22 +30,8 @@ const getCozyClient = function (environment = 'production') {
   })
   newCozyClient.models = models
 
-  const options = {
-    cozyURL: newCozyClient.stackClient.uri
-  }
-  if (environment === 'development') {
-    options.oauth = { storage: new MemoryStorage() }
-  } else if (environment === 'production') {
-    options.token = process.env.COZY_CREDENTIALS
-  }
-  const cozyClient = new Client(options)
-  if (environment === 'development') {
-    const credentials = JSON.parse(process.env.COZY_CREDENTIALS)
-    credentials.token.toAuthHeader = function () {
-      return 'Bearer ' + credentials.client.registrationAccessToken
-    }
-    cozyClient.saveCredentials(credentials.oauthOptions, credentials.token)
-  }
+  const cozyClient = cozyClientJsFromEnv(newCozyClient.stackClient.uri)
+
   cozyClient.new = newCozyClient
   return cozyClient
 }
@@ -73,5 +58,33 @@ const cozyClient = getCozyClient(
   // since we do not want to minimize the built file, we recognize the 'none' mode as production mode
   process.env.NODE_ENV === 'none' ? 'production' : process.env.NODE_ENV
 )
+
+function cozyClientJsFromEnv(cozyURL) {
+  const options = { cozyURL }
+  let jsonCredentials = null
+  if (process.env.COZY_CREDENTIALS) {
+    try {
+      jsonCredentials = JSON.parse(process.env.COZY_CREDENTIALS)
+    } catch (err) {
+      options.token = process.env.COZY_CREDENTIALS
+    }
+  }
+
+  if (jsonCredentials) {
+    options.oauth = { storage: new MemoryStorage() }
+  }
+
+  const cozyClient = new Client(options)
+
+  if (jsonCredentials) {
+    jsonCredentials.token.toAuthHeader = function () {
+      return 'Bearer ' + jsonCredentials.client.registrationAccessToken
+    }
+    cozyClient.saveCredentials(
+      jsonCredentials.oauthOptions,
+      jsonCredentials.token
+    )
+  }
+}
 
 module.exports = cozyClient


### PR DESCRIPTION
Also fixes cozy-run-dev command

This way of initializing cozyClient is now not dependent of NODE_ENV but instead of the present of credentials in environment variables.