### PR TITLE
fix: Use the right mimeTypes function for content type

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -389,7 +389,7 @@ async function createFile(entry, options, method, fileId) {
   }
   if (options.contentType) {
     if (options.contentType === true && entry.filename) {
-      createFileOptions.contentType = mimetypes.contentType(entry.filename)
+      createFileOptions.contentType = mimetypes.contentType(path.extname(entry.filename))
     } else {
       createFileOptions.contentType = options.contentType
     }


### PR DESCRIPTION
If the filename would contain / char, the returned content type was the
filename.
A not expected contentType can cause a lot of problems in our
infrastructure.

Instead, the lookup function expects a complete filename

In parallel, a fix is done in the stack to validate the content type
properly.
