### PR TITLE
feat: remove --fix option on lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepublish": "npm run lint",
     "publish": "lerna publish",
     "bootstrap": "lerna bootstrap",
-    "lint": "eslint . --fix",
+    "lint": "eslint .",
     "test": "cross-env LOG_LEVEL=info jest"
   },
   "jest": {


### PR DESCRIPTION
The --fix option can make release fail because of modified files

We prefer to have the build fail earlier in the pull request
