### PR TITLE
Use dynamic import instead of require

### DIFF
--- a/packages/cozy-jobs-cli/src/konnector-standalone.js
+++ b/packages/cozy-jobs-cli/src/konnector-standalone.js
@@ -43,7 +43,7 @@ initReplay()
 process.env.SENTRY_DSN = 'false'
 
 if (fs.existsSync(path.resolve(filename))) {
-  require(require('path').resolve(filename))
+  import(require('path').resolve(filename))
 } else {
   console.log(
     `ERROR: File ${path.resolve(


### PR DESCRIPTION
This allows to write konnectors as ES module (while still keeping backward compatibility).

Partially fixes #635