### PR TITLE
fix: Add default value to createCategorizer

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/categorization/index.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/index.js
@@ -47,7 +47,7 @@ const log = logger.namespace('categorization')
  *   }
  * }
  */
-async function createCategorizer(options) {
+async function createCategorizer(options = {}) {
   const {
     useGlobalModel = true,
     customTransactionFetcher,


### PR DESCRIPTION
This also fixes categorizer unit tests

```
 FAIL  src/libs/categorization/index.spec.js
  ● createCategorizer › should create an object with a categorize method

    TypeError: Cannot read property 'useGlobalModel' of undefined

      50 | async function createCategorizer(options) {
      51 |   const {
    > 52 |     useGlobalModel = true,
         |     ^
      53 |     customTransactionFetcher,
      54 |     pretrainedClassifier
      55 |   } = options

      at createCategorizer (src/libs/categorization/index.js:52:5)
      at Object.<anonymous> (src/libs/categorization/index.spec.js:18:31)

  ● createCategorizer › should initialize global and local models

    TypeError: Cannot read property 'useGlobalModel' of undefined

      50 | async function createCategorizer(options) {
      51 |   const {
    > 52 |     useGlobalModel = true,
         |     ^
      53 |     customTransactionFetcher,
      54 |     pretrainedClassifier
      55 |   } = options

      at createCategorizer (src/libs/categorization/index.js:52:5)
      at Object.<anonymous> (src/libs/categorization/index.spec.js:24:11)

```