### PR TITLE
feat: Allow devs to pass COZY_FIELDS values

### DIFF
--- a/packages/cozy-jobs-cli/src/konnector-dev.js
+++ b/packages/cozy-jobs-cli/src/konnector-dev.js
@@ -9,6 +9,9 @@ process.env.COZY_URL = config.COZY_URL
 if (config.COZY_PARAMETERS) {
   process.env.COZY_PARAMETERS = JSON.stringify(config.COZY_PARAMETERS)
 }
+if (config.COZY_FIELDS) {
+  process.env.COZY_FIELDS = JSON.stringify(config.COZY_FIELDS)
+}
 // sentry is not needed in dev mode
 process.env.SENTRY_DSN = 'false'
 
@@ -46,6 +49,7 @@ const ensureStackAccount = async config => {
     fs.writeFileSync(DEFAULT_ACCOUNT_PATH, newAccount._id)
   }
   process.env.COZY_FIELDS = JSON.stringify({
+    ...(process.env.COZY_FIELDS ? JSON.parse(process.env.COZY_FIELDS) : {}),
     account: accountId
   })
 }


### PR DESCRIPTION
When launching a connector (e.g. using `yarn dev` for a banking
connector), we want to be able to pass `COZY_FIELDS` values as
`cozy-stack` would.
Since we can already pass `COZY_URL` via the
`konnector-dev-config.json` file, it seems appropriate to add the
ability to pass `COZY_FIELDS` via this file as well.

The given fields will be merged with the `accountId` field from the
`.account` file for backward compatibility.