### PR TITLE
fix: Replace cozy.tools with cozy.localhost

### DIFF
--- a/packages/cozy-jobs-cli/README.md
+++ b/packages/cozy-jobs-cli/README.md
@@ -28,4 +28,4 @@ You can use `COZY_URL` to connect to another cozy.
 - Provides `COZY_CREDENTIALS` to the locally running connector from `konnector-dev-config.json` (which is created if it does not exist)
 - Does not save the data in a real cozy but instead dumps the data to `importedData.json`
 
-You can use `COZY_URL` to connect to another cozy. The default one is `cozy.tools:8080`.
+You can use `COZY_URL` to connect to another cozy. The default one is `cozy.localhost:8080`.

--- a/packages/cozy-jobs-cli/src/cozy-authenticate.js
+++ b/packages/cozy-jobs-cli/src/cozy-authenticate.js
@@ -19,7 +19,7 @@ async function authenticate({ manifestPath, tokenPath }) {
     {
       uri: process.env.COZY_URL
         ? process.env.COZY_URL
-        : 'http://cozy.tools:8080',
+        : 'http://cozy.localhost:8080',
       scope: scopes,
       oauth: {
         softwareID: 'dev-connector'

--- a/packages/cozy-jobs-cli/src/init-konnector-config.js
+++ b/packages/cozy-jobs-cli/src/init-konnector-config.js
@@ -16,7 +16,7 @@ function getKonnectorConfig() {
 }
 
 const template = {
-  COZY_URL: 'http://cozy.tools:8080', // this URL resolves to localhost, it works well when you have running local cozy-stack
+  COZY_URL: 'http://cozy.localhost:8080', // this URL resolves to localhost, it works well when you have running local cozy-stack
   fields: {} // TODO read the fields in the manifest and add these fields in the template
 }
 

--- a/packages/cozy-jobs-cli/src/run-dev.js
+++ b/packages/cozy-jobs-cli/src/run-dev.js
@@ -41,7 +41,7 @@ const token = program.token || DEFAULT_TOKEN_PATH
 
 process.env.COZY_URL = process.env.COZY_URL
   ? process.env.COZY_URL
-  : 'http://cozy.tools:8080'
+  : 'http://cozy.localhost:8080'
 
 authenticate({ tokenPath: token, manifestPath: manifest })
   .then(client => {


### PR DESCRIPTION
Since this is the default local url of cozy stack now
