### PR TITLE
fix: Do not rely on cwd to read a file payload

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -10,6 +10,7 @@ const omit = require('lodash/omit')
 const updateOrCreate = require('./updateOrCreate')
 const saveIdentity = require('./saveIdentity')
 const fs = require('fs').promises
+const path = require('path')
 const {
   wrapIfSentrySetUp,
   captureExceptionAndDie
@@ -180,7 +181,8 @@ class BaseKonnector {
     const isFileReference = get(cozyPayload, '[0]') === '@'
 
     if (isFileReference) {
-      const filePath = cozyPayload.substr(1)
+      const fileName = cozyPayload.substr(1)
+      const filePath = path.resolve(__dirname, fileName)
       try {
         const fileContent = await fs.readFile(filePath)
         return JSON.parse(fileContent)

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.spec.js
@@ -22,6 +22,7 @@ const signin = require('./signin')
 const BaseKonnector = require('./BaseKonnector')
 const logger = require('cozy-logger')
 const fs = require('fs').promises
+const path = require('path')
 
 logger.setLevel('error')
 
@@ -297,7 +298,9 @@ describe('readPayload', () => {
 
     const connector = new BaseKonnector()
     const result = await connector.readPayload()
-    expect(fs.readFile).toHaveBeenCalledWith('test.json')
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.resolve(__dirname, 'test.json')
+    )
     expect(result).toEqual({ testfilepayload: 'testfilepayloadvalue' })
   })
   it('should throw on wrong JSON string', async () => {
@@ -312,10 +315,12 @@ describe('readPayload', () => {
     fs.readFile.mockResolvedValue(`{ testfilepayload: testfilepayloadvalue}`)
 
     const connector = new BaseKonnector()
-    await expect(() =>
-      connector.readPayload()
-    ).rejects.toThrowErrorMatchingSnapshot()
-    expect(fs.readFile).toHaveBeenCalledWith('test2.json')
+    await expect(() => connector.readPayload()).rejects.toThrow(
+      'Error while reading file'
+    )
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.resolve(__dirname, 'test2.json')
+    )
   })
   it('should return null if no payload', async () => {
     const connector = new BaseKonnector()

--- a/packages/cozy-konnector-libs/src/libs/__snapshots__/BaseKonnector.spec.js.snap
+++ b/packages/cozy-konnector-libs/src/libs/__snapshots__/BaseKonnector.spec.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`readPayload should throw on wrong JSON file 1`] = `"Error while reading file test2.json payload: Unexpected token t in JSON at position 2"`;
-
 exports[`readPayload should throw on wrong JSON string 1`] = `"Could not parse JSON in COZY_PAYLOAD: { testPayload: testpayloadvalue}"`;


### PR DESCRIPTION
Depending on the environment in which the connector is run, we have some problems to read a JSON payload, given as a file by the cozy stack

1) the current working directory with which the connector is run can vary and we cannot depend on it
2) if compiled with webpack with default value like the connector template, the __dirname value is set to "/"

To solve 1) we can use path.resolve(__dirname, filename) to read the payload but this supposes 2) is also solved.

To solve 2), we need to pass the `node: {__dirname: false}` option to webpack. See https://codeburst.io/use-webpack-with-dirname-correctly-4cad3b265a92

The connector template will be updated with the correct webpack configuration