### PR TITLE
fix: No error when assets and travis conf missing

### DIFF
--- a/packages/cozy-konnector-build/webpack.config.js
+++ b/packages/cozy-konnector-build/webpack.config.js
@@ -55,8 +55,8 @@ module.exports = {
         { from: 'manifest.konnector' },
         { from: 'package.json' },
         { from: 'README.md' },
-        { from: 'assets', transform: optimizeSVGIcon },
-        { from: '.travis.yml' },
+        { from: 'assets', transform: optimizeSVGIcon, noErrorOnMissing: true },
+        { from: '.travis.yml', noErrorOnMissing: true },
         { from: 'LICENSE' }
       ]
     }),


### PR DESCRIPTION
Do not trigger webpack error when the assets directory and travis
configuration file are missing. Some conectors like banking connectors
do not use travis or assets directory. And this is a rule which is
harder to override with webpack-merge.

I prefer to keep the other files mandatories to detect configuration
errors sooner.
