### PR TITLE
chore: Remove unneeded files from build asset

### DIFF
--- a/packages/cozy-konnector-build/webpack.config.js
+++ b/packages/cozy-konnector-build/webpack.config.js
@@ -53,11 +53,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: 'manifest.konnector' },
-        { from: 'package.json' },
-        { from: 'README.md' },
-        { from: 'assets', transform: optimizeSVGIcon, noErrorOnMissing: true },
-        { from: '.travis.yml', noErrorOnMissing: true },
-        { from: 'LICENSE' }
+        { from: 'assets', transform: optimizeSVGIcon, noErrorOnMissing: true }
       ]
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
Remove unused README, LICENCE and .travis.yml files from built archive

These files are unneeded and removing them make the package smaller to download and execute on servers
