### PR TITLE
Fix: force cozy-client-js stack version

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/cozyclient.js
+++ b/packages/cozy-konnector-libs/src/libs/cozyclient.js
@@ -60,7 +60,11 @@ const cozyClient = getCozyClient(
 )
 
 function cozyClientJsFromEnv(cozyURL) {
-  const options = { cozyURL }
+  // version is hardcoded to 3 here to avoid fetching instance's /status looking for obsolete nodezy
+  const options = {
+    cozyURL,
+    version: 3
+  }
   let jsonCredentials = null
   if (process.env.COZY_CREDENTIALS) {
     try {


### PR DESCRIPTION
When instanciating cozy-client-js, it requests instance's `/status` to determine if it is talking to an old cozy v2 (nodezy) or to a cozy v3 (gozy).

Because there is no cozy v2 anymore and our konnectors are now incompatible with obsolete nodezy, this PR forces instance version to 3 to avoid one useless request to instance's `/status`