### PR TITLE
build: Explicit entry point in webpack

### DIFF
--- a/packages/cozy-konnector-build/webpack.config.js
+++ b/packages/cozy-konnector-build/webpack.config.js
@@ -6,11 +6,6 @@ const SvgoInstance = require('svgo')
 
 const currentDirectory = process.cwd()
 
-const readPackageJson = () =>
-  JSON.parse(fs.readFileSync(path.join(currentDirectory, './package.json')))
-
-const entry = readPackageJson().main
-
 const readManifest = () =>
   JSON.parse(
     fs.readFileSync(path.join(currentDirectory, './manifest.konnector'))
@@ -37,7 +32,7 @@ try {
 const appIconRX = iconName && new RegExp(`[^/]*/${iconName}`)
 
 module.exports = {
-  entry,
+  entry: './src/index.js',
   target: 'node',
   mode: 'none',
   node: {


### PR DESCRIPTION
Remove the reference to entry point in package.json, and explicit the index.js used


Work in progress, we need to confirm the good behaviour before merge and auto publishing this package.
