### PR TITLE
fix: publish built version of cozy-ccc-libs

### DIFF
--- a/packages/cozy-clisk/package.json
+++ b/packages/cozy-clisk/package.json
@@ -12,6 +12,9 @@
   "keywords": [
     "konnector"
   ],
+  "exports": {
+    "./*": "./dist/*.js"
+  },
   "author": "doubleface <christophe@cozycloud.cc>",
   "license": "MIT",
   "bugs": {

--- a/packages/cozy-clisk/package.json
+++ b/packages/cozy-clisk/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/konnectors/libs.git"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "konnector"
   ],
@@ -17,6 +20,7 @@
   "homepage": "https://github.com/konnectors/libs#readme",
   "scripts": {
     "lint": "eslint 'src/**/*.js'",
+    "prepublishOnly": "yarn run build",
     "build": "babel src/ -d dist/ --copy-files --verbose --ignore '**/*.spec.js','**/*.spec.jsx'",
     "test": "jest src"
   },


### PR DESCRIPTION
There was no dist file in last version of cozy-ccc-libs.

This package is now built before publish and only the dist folder is  published.

Fixed the readme file accordingly