### PR TITLE
(ccc-libs)feat: Migrating saveFiles to cozy-client

### DIFF
--- a/packages/cozy-ccc-libs/package.json
+++ b/packages/cozy-ccc-libs/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "bluebird-retry": "^0.11.0",
-    "cozy-client": "^34.7.1",
+    "cozy-client": "^34.11.0",
     "cozy-client-js": "^0.20.0",
     "ky": "^0.25.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5896,16 +5896,16 @@ cozy-client@^33.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^34.7.1:
-  version "34.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.7.1.tgz#d0641b43dbf67ca33a4ccae2a9a62b24784c2e1f"
-  integrity sha512-3KDrVOCMVnsxLcuCggM/rL13cIh+jY2MKZmHDZVM0cF8HeGMDHOJSH7cGwyL6vEoEzo6K2bxqPafJaIRqgw9Mw==
+cozy-client@^34.11.0:
+  version "34.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-34.11.0.tgz#f6877b9eb9080fd1d509cdbcf59473560f282392"
+  integrity sha512-EENMenuECpCe1k8InnoSiI4lpJ20hbfcrBNh5KYTRhHnAzBmrxikzzxEGB5VMzX5bq48Rm94pjpqzNeD0heLEQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^34.7.1"
+    cozy-stack-client "^34.11.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -5980,10 +5980,10 @@ cozy-stack-client@^33.2.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-stack-client@^34.7.1:
-  version "34.7.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.7.1.tgz#f1b81cce2c88ba558a1b5995a91674462f3e629c"
-  integrity sha512-iarCc6y79HCcQKM7ITQX+y3Tvhi1SjtMGonKAkA98MOtB7qBBolU0CJd9CTLyRfzJAVT/VpXHpwBwTLQ5tyo4g==
+cozy-stack-client@^34.11.0:
+  version "34.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-34.11.0.tgz#2c6a6f33b0a935c4d491077d7a4f85e8d2a542b2"
+  integrity sha512-rl6FKFY6r8fhnihBnrsLOS0F0xdvx/2YG6Ok/Yk9OKIsm0GMAn4DIq15xv4XLpHkxSyJLHBX+pZBtdfAFq7wJg==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
Reporting the migration to cozy-client in saveFiles of the ccc-libs
Flagship app master Launch.js is already up-to-date for the new saveFiles prototype (client 1st arg)