### PR TITLE
Feat/get classifier options

### DIFF
--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -36,8 +36,13 @@ const TOKENS_TO_REWEIGHT = [
   'tag_pos tag_activity_income'
 ]
 
-const getClassifierOptions = uniqueCategories => {
-  const nbUniqueCategories = uniqueCategories.length
+/**
+ * Get the classifier options, mainly to get the alpha parameter
+ *
+ * @param {number} nbUniqueCategories - Number of unique categories
+ * @returns {object} the classifier options
+ */
+const getClassifierOptions = nbUniqueCategories => {
   log(
     'debug',
     'Number of unique categories in transactions with manual categories: ' +
@@ -166,7 +171,7 @@ const createClassifier = async options => {
   log('debug', 'Instanciating a new classifier')
 
   const nbUniqueCategories = getUniqueCategories(transactions)
-  const classifierOptions = getClassifierOptions(nbUniqueCategories)
+  const classifierOptions = getClassifierOptions(nbUniqueCategories.length)
   const classifier = createLocalClassifier(
     transactions,
     { ...remainingOptions, ...classifierOptions.initialization },

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -170,8 +170,8 @@ const createClassifier = async options => {
 
   log('debug', 'Instanciating a new classifier')
 
-  const nbUniqueCategories = getUniqueCategories(transactions)
-  const classifierOptions = getClassifierOptions(nbUniqueCategories.length)
+  const uniqueCategories = getUniqueCategories(transactions)
+  const classifierOptions = getClassifierOptions(uniqueCategories?.length || 0)
   const classifier = createLocalClassifier(
     transactions,
     { ...remainingOptions, ...classifierOptions.initialization },

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -36,8 +36,7 @@ const TOKENS_TO_REWEIGHT = [
   'tag_pos tag_activity_income'
 ]
 
-const getClassifierOptions = transactionsWithManualCat => {
-  const uniqueCategories = getUniqueCategories(transactionsWithManualCat)
+const getClassifierOptions = uniqueCategories => {
   const nbUniqueCategories = uniqueCategories.length
   log(
     'debug',
@@ -166,7 +165,8 @@ const createClassifier = async options => {
 
   log('debug', 'Instanciating a new classifier')
 
-  const classifierOptions = getClassifierOptions(transactions)
+  const nbUniqueCategories = getUniqueCategories(transactions)
+  const classifierOptions = getClassifierOptions(nbUniqueCategories)
   const classifier = createLocalClassifier(
     transactions,
     { ...remainingOptions, ...classifierOptions.initialization },

--- a/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
+++ b/packages/cozy-konnector-libs/src/libs/categorization/localModel/classifier.js
@@ -189,5 +189,6 @@ const createClassifier = async options => {
 }
 
 module.exports = {
-  createClassifier
+  createClassifier,
+  getClassifierOptions
 }


### PR DESCRIPTION
`getClassifierOptions` only needs the number of classes to get the options, we were providing the full array of transactions. This is a more general approach that will fit other use cases.

We took the liberty of NOT marking the breaking change because it affects a previously unexported method that is not used anywhere but in the DisseCozy POC (c.f. #921)