### PR TITLE
fix: Babel transpilation

### DIFF
--- a/packages/cozy-clisk/package.json
+++ b/packages/cozy-clisk/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "eslint 'src/**/*.js'",
     "prepublishOnly": "yarn run build",
-    "build": "babel src/ -d dist/ --copy-files --verbose --ignore '**/*.spec.js','**/*.spec.jsx'",
+    "build": "babel --root-mode upward src/ -d dist/ --copy-files --verbose --ignore '**/*.spec.js','**/*.spec.jsx'",
     "test": "jest src"
   },
   "devDependencies": {

--- a/packages/cozy-konnector-libs/package.json
+++ b/packages/cozy-konnector-libs/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "build": "yarn run transpile",
-    "transpile": "rm -rf dist/* ; babel src --out-dir dist",
+    "transpile": "rm -rf dist/* ; babel --root-mode upward src --out-dir dist",
     "prepublishOnly": "yarn run transpile",
     "test": "cross-env LOG_LEVEL=info jest ./src",
     "docs": "jsdoc2md --template jsdoc2md/README.hbs src/libs/*.js src/helpers/*.js src/libs/categorization/index.js > docs/api.md",


### PR DESCRIPTION
It seems that when we publish the mono-repo we're running our Babel compilation process from within the subpackages.

By doing so, babel is not aware of the root configuration files. So the babel config doesn't apply.

To fix that we need to pass `--root-mode upward` which will make Babel search from the working directory upward looking for the babel.config.json

See https://babeljs.io/docs/config-files#root-babelconfigjson-file for babel documentation

This commit fix the issue where we had an optional chaining in our dist/ folder.