### PR TITLE
fix: Remove cozy-client-js dependency in cozy-clisk

### DIFF
--- a/packages/cozy-clisk/package.json
+++ b/packages/cozy-clisk/package.json
@@ -37,7 +37,6 @@
     "@cozy/minilog": "^1.0.0",
     "bluebird-retry": "^0.11.0",
     "cozy-client": "^34.11.0",
-    "cozy-client-js": "^0.20.0",
     "ky": "^0.25.1",
     "lodash": "^4.17.21",
     "p-wait-for": "^3.0.0",


### PR DESCRIPTION
Since it is no longer used
