### PR TITLE
feat: Add getCliskVersion method

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -436,6 +436,7 @@ export default class ContentScript {
    * @param {string} message : the log message
    */
   log(level, message) {
+    let newLevel = level
     const allowedLevels = ['debug', 'info', 'warn', 'error']
     if (!message) {
       log.warn(
@@ -444,12 +445,12 @@ export default class ContentScript {
       return
     }
     if (!allowedLevels.includes(level)) {
-      level = 'debug'
+      newLevel = 'debug'
     }
     const now = new Date()
     this.bridge?.emit('log', {
       timestamp: now,
-      level,
+      level: newLevel,
       msg: message
     })
   }

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -36,6 +36,7 @@ export default class ContentScript {
     const logInfo = message => this.log('info', message)
     const wrapTimerInfo = wrapTimerFactory({ logFn: logInfo })
     this.ensureAuthenticated = wrapTimerInfo(this, 'ensureAuthenticated')
+    this.ensureNotAuthenticated = wrapTimerInfo(this, 'ensureNotAuthenticated')
     this.getUserDataFromWebsite = wrapTimerInfo(this, 'getUserDataFromWebsite')
     this.fetch = wrapTimerInfo(this, 'fetch')
     this.waitForAuthenticated = wrapTimerDebug(this, 'waitForAuthenticated')
@@ -94,6 +95,7 @@ export default class ContentScript {
     const exposedMethodsNames = [
       'setContentScriptType',
       'ensureAuthenticated',
+      'ensureNotAuthenticated',
       'checkAuthenticated',
       'waitForAuthenticated',
       'waitForElementNoReload',
@@ -487,7 +489,7 @@ export default class ContentScript {
   }
 
   /**
-   * Make sur that the connector is authenticated to the website.
+   * Make sure that the connector is authenticated to the website.
    * If not, show the login webview to the user to let her/him authenticated.
    * Resolve the promise when authenticated
    *
@@ -495,6 +497,15 @@ export default class ContentScript {
    * @returns {Promise.<boolean>} : true if the user is authenticated
    */
   async ensureAuthenticated() {
+    return true
+  }
+
+  /**
+   * Make sure that the connector is not authenticated anymore to the website.
+   *
+   * @returns {Promise.<boolean>} : true if the user is not authenticated
+   */
+  async ensureNotAuthenticated() {
     return true
   }
 

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -6,6 +6,7 @@ import LauncherBridge from '../bridge/LauncherBridge'
 import { blobToBase64 } from './utils'
 import { wrapTimerFactory } from '../libs/wrapTimer'
 import ky from 'ky/umd'
+import cliskPackageJson from '../../package.json'
 
 const log = Minilog('ContentScript class')
 
@@ -107,7 +108,8 @@ export default class ContentScript {
       'clickAndWait',
       'getCookiesByDomain',
       'getCookieByDomainAndName',
-      'downloadFileInWorker'
+      'downloadFileInWorker',
+      'getCliskVersion'
     ]
 
     if (options.additionalExposedMethodsNames) {
@@ -558,6 +560,13 @@ export default class ContentScript {
    */
   // eslint-disable-next-line no-unused-vars
   async fetch(options) {}
+
+  /**
+   * Returns the current clisk version number in package.json file
+   */
+  async getCliskVersion() {
+    return cliskPackageJson.version
+  }
 }
 
 function sendPageMessage(message) {


### PR DESCRIPTION
Callable by the launcher, it return the current version of clisk from its package.json version

It will allow the launcher to call some ContentScript methods only when available