### PR TITLE
fix: Not intercepted worker errors

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -179,7 +179,7 @@ export default class ContentScript {
         'No bridge is defined, you should call ContentScript.init before using this method'
       )
     }
-    return this.bridge.call('runInWorker', method, ...args)
+    return await this.bridge.call('runInWorker', method, ...args)
   }
 
   /**

--- a/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
@@ -1,11 +1,24 @@
 import ContentScript, { PILOT_TYPE } from './ContentScript'
 
 describe('ContentScript', () => {
-  const contentScript = new ContentScript()
-  contentScript.setContentScriptType(PILOT_TYPE)
+  describe('runInWorker', () => {
+    const contentScript = new ContentScript()
+    contentScript.setContentScriptType(PILOT_TYPE)
+    it('should throw an error met in the worker', async () => {
+      contentScript.bridge = {
+        call: jest.fn().mockRejectedValue(new Error('worker error'))
+      }
+
+      await expect(() => contentScript.runInWorker('test')).rejects.toThrow(
+        'worker error'
+      )
+    })
+  })
 
   describe('runInWorkerUntilTrue', () => {
-    contentScript.runInWorker = jest.fn()
+    const contentScript = new ContentScript()
+    contentScript.setContentScriptType(PILOT_TYPE)
+    jest.spyOn(contentScript, 'runInWorker')
     contentScript.tocall = jest.fn()
 
     it('should resolve with result of the specified method returns truthy value', async () => {


### PR DESCRIPTION
Error which were raised on the worker were not intercepted by the
launcher.

Ex: this.waitForElementInworker with a non existing element

This resulted in timeout unhandled promise error

Now the runInWorker promise is awaited and errors are caught and handled
by the launcher

Currently working on a unit test on this subject
