### PR TITLE
feat: Allow waitForElementInWorker to set its own timeout

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -216,11 +216,14 @@ export default class ContentScript {
    * reloads
    *
    * @param {string} selector - css selector we are waiting for
+   * @param {object} options - options object
+   * @param {number} [options.timeout] - timeout in ms. Will default to 30s
    */
-  async waitForElementInWorker(selector) {
+  async waitForElementInWorker(selector, options = {}) {
     this.onlyIn(PILOT_TYPE, 'waitForElementInWorker')
     await this.runInWorkerUntilTrue({
       method: 'waitForElementNoReload',
+      timeout: options?.timeout,
       args: [selector]
     })
   }


### PR DESCRIPTION
The default timeout for `waitForElementInWorker` was previously 30s. Sometimes, when the website is slow, en element may take more than 30s to display.

It is now possible to specify the timeout of this command, to have a longer or shorter timeout.


Now waitForElementInWorker can be called like this : 

```javascript
this.waitForElementInWorker(selector, {
  timeout: 100000 // for 100s
})
```