### PR TITLE
feat: Centralize clisk webpack configuration

### DIFF
--- a/packages/cozy-konnector-build/webpack.config.clisk.js
+++ b/packages/cozy-konnector-build/webpack.config.clisk.js
@@ -1,0 +1,15 @@
+const path = require('path')
+const CopyPlugin = require('copy-webpack-plugin')
+
+module.exports = {
+  mode: 'none',
+  output: {
+    path: path.join(process.cwd(), 'build'),
+    filename: 'main.js'
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [{ from: 'manifest.konnector' }, { from: 'assets' }]
+    })
+  ]
+}


### PR DESCRIPTION
To replace clisk konnectors webpack configuration with

```javascript
module.exports = require('cozy-konnector-build/webpack.config.clisk')
```

And have the possibility to update webpack configuration on all clisk
konnectors with just a package update
