### PR TITLE
 feat: Allow to watch and update a konnector on local cozy stack 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ packages/*/node_modules/*
 yarn-error.log
 packages/*/dist/*
 .changelog/*
+**/.vscode/*

--- a/packages/cozy-konnector-build/package.json
+++ b/packages/cozy-konnector-build/package.json
@@ -24,7 +24,8 @@
     "git-directory-deploy": "1.5.1",
     "husky": "4.3.8",
     "svgo": "1.3.2",
-    "webpack": "5.76.0",
-    "webpack-cli": "4.9.2"
+    "webpack": "5.68.0",
+    "webpack-cli": "4.9.2",
+    "webpack-shell-plugin-next": "^2.3.1"
   }
 }

--- a/packages/cozy-konnector-build/webpack.config.clisk.js
+++ b/packages/cozy-konnector-build/webpack.config.clisk.js
@@ -1,5 +1,26 @@
 const path = require('path')
+const fs = require('fs')
 const CopyPlugin = require('copy-webpack-plugin')
+const { configureDeployOnLocalStack } = require('./webpack.config.deploy.js')
+
+const currentDirectory = process.cwd()
+const readManifest = () =>
+  JSON.parse(
+    fs.readFileSync(path.join(currentDirectory, './manifest.konnector'))
+  )
+const manifest = readManifest()
+
+let plugins = [
+  new CopyPlugin({
+    patterns: [{ from: 'manifest.konnector' }, { from: 'assets' }]
+  })
+]
+
+plugins = configureDeployOnLocalStack(
+  process.env.UPDATE_ON_LOCAL_COZY_STACK,
+  plugins,
+  manifest.slug
+)
 
 module.exports = {
   mode: 'none',
@@ -7,9 +28,5 @@ module.exports = {
     path: path.join(process.cwd(), 'build'),
     filename: 'main.js'
   },
-  plugins: [
-    new CopyPlugin({
-      patterns: [{ from: 'manifest.konnector' }, { from: 'assets' }]
-    })
-  ]
+  plugins
 }

--- a/packages/cozy-konnector-build/webpack.config.deploy.js
+++ b/packages/cozy-konnector-build/webpack.config.deploy.js
@@ -1,0 +1,23 @@
+const WebpackShellPlugin = require('webpack-shell-plugin-next')
+
+module.exports.configureDeployOnLocalStack = (
+  UPDATE_ON_LOCAL_COZY_STACK,
+  plugins,
+  slug
+) => {
+  // when $UPDATE_ON_LOCAL_COZY_STACK env var is defined, update it automatically on local
+  // cozy stack which will use $COZY_DOMAIN env var to know which cozy-stack instance to
+  // target (cozy.localhost:8080 by default)
+  if (UPDATE_ON_LOCAL_COZY_STACK) {
+    return [
+      ...plugins,
+      new WebpackShellPlugin({
+        onAfterDone: {
+          scripts: [`cozy-stack konnectors update ${slug}`],
+          blocking: true // to wait for the end command execution
+        }
+      })
+    ]
+  }
+  return plugins
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13280,6 +13280,11 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-shell-plugin-next@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.1.tgz#a7bcf7aeeb4143ec8de261194e2b029459b3ae6d"
+  integrity sha512-+ozr/BcsuPh2R6j4oxmu9qJCInhhDCQ+Lb/sSUNHuXjoGj+myxxZyjucHze+K9dCoIo22gAoK1yuCP/gSnpUNg==
+
 webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"


### PR DESCRIPTION
With this, if you update cozy-konnector-build on your konnector (clisk
or node), you can have the konnector on you local stack updated in
realtime for each modification of your konnector or its dependencies.

The command :

```
cozy-stack konnectors update <slug from current manifest>
```

is run after each source code modification.

The targetted cozy-stack instance is chosen by the cozy-stack command
with the $COZY_DOMAIN environment variable and targets
http://cozy.localhost:8080/ by default.

To make it easier to use, add

```javascript
{
  "scripts": {
    "watchDeploy": "UPDATE_ON_LOCAL_COZY_STACK=true yarn watch"
  }
}
```

to your konnector's package.json file