### PR TITLE
feat: Add evaluateInWorker method

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -3,7 +3,7 @@ import waitFor, { TimeoutError } from 'p-wait-for'
 import Minilog from '@cozy/minilog'
 
 import LauncherBridge from '../bridge/LauncherBridge'
-import { blobToBase64 } from './utils'
+import { blobToBase64, callStringFunction } from './utils'
 import { wrapTimerFactory } from '../libs/wrapTimer'
 import ky from 'ky/umd'
 import cliskPackageJson from '../../package.json'
@@ -110,7 +110,8 @@ export default class ContentScript {
       'getCookieByDomainAndName',
       'downloadFileInWorker',
       'getCliskVersion',
-      'checkForElement'
+      'checkForElement',
+      'evaluate'
     ]
 
     if (options.additionalExposedMethodsNames) {
@@ -522,6 +523,30 @@ export default class ContentScript {
   async goto(url) {
     this.onlyIn(PILOT_TYPE, 'goto')
     await this.setWorkerState({ url })
+  }
+
+  /**
+   * Evaluates a given function in worker context
+   *
+   * @param {Function} fn - the function to evaluate
+   *
+   * @returns {Promise<any>} - function evaluation result
+   */
+  async evaluateInWorker(fn, ...args) {
+    this.onlyIn(PILOT_TYPE, 'evaluateInWorker')
+    return await this.runInWorker('evaluate', fn.toString(), ...args)
+  }
+
+  /**
+   * Evaluates a given function string
+   *
+   * @param {String} fnString - the function string to evaluate
+   *
+   * @returns {Promise<any>} - function evaluation result
+   */
+  async evaluate(fnString, ...args) {
+    this.onlyIn(WORKER_TYPE, 'evaluate')
+    return await callStringFunction(fnString, ...args)
   }
 
   /**

--- a/packages/cozy-clisk/src/contentscript/utils.js
+++ b/packages/cozy-clisk/src/contentscript/utils.js
@@ -4,7 +4,7 @@
  * @param {Blob} blob : blob object
  * @returns {Promise.<string>} : base64 form of the blob
  */
-async function blobToBase64(blob) {
+export async function blobToBase64(blob) {
   const reader = new window.FileReader()
   await new Promise((resolve, reject) => {
     reader.onload = resolve
@@ -14,4 +14,25 @@ async function blobToBase64(blob) {
   return reader.result
 }
 
-export { blobToBase64 }
+/**
+ * Convert a string function to the corresponding function.
+ *
+ * @param {String} fnString - function string to convert
+ *
+ * @returns {Function} - the resulting function
+ */
+export function deserializeStringFunction(fnString) {
+  return eval('(' + fnString.trim() + ')')
+}
+
+/**
+ * Calls and awaits the given string function with given arguments
+ *
+ * @param {String} fnString - function string to convert
+ *
+ * @returns {Promise<any>} - the result of the execution of the string function
+ */
+export async function callStringFunction(fnString, ...args) {
+  const fn = deserializeStringFunction(fnString)
+  return await fn(...args)
+}

--- a/packages/cozy-clisk/src/contentscript/utils.spec.js
+++ b/packages/cozy-clisk/src/contentscript/utils.spec.js
@@ -1,0 +1,43 @@
+import { callStringFunction, deserializeStringFunction } from './utils.js'
+
+describe('deserializeStringFunction', () => {
+  it('should parse simple function string', async () => {
+    function fnStart(n) {
+      return n + 1
+    }
+    const fnResult = deserializeStringFunction(fnStart.toString())
+    const result = fnResult(3)
+    expect(result).toEqual(4)
+  })
+  it('should parse arrow functions', () => {
+    const fnStart = n => n + 1
+    const fnResult = deserializeStringFunction(fnStart.toString())
+    const result = fnResult(5)
+    expect(result).toEqual(6)
+  })
+})
+
+describe('callStringFunction', () => {
+  it('should call a simple function with given parameters', async () => {
+    function fnStart(n) {
+      return n * 2
+    }
+    const result = await callStringFunction(fnStart.toString(), 3)
+    expect(result).toEqual(6)
+  })
+  it('should await function returning Promises', async () => {
+    function fnStart(n) {
+      return new Promise(resolve => {
+        window.setTimeout(() => resolve(n - 1), 10)
+      })
+    }
+    const result = await callStringFunction(fnStart.toString(), 3)
+    expect(result).toEqual(2)
+  })
+  it('should await arrow function returning Promises', async () => {
+    const fnStart = n =>
+      new Promise(resolve => window.setTimeout(() => resolve(n * 3)))
+    const result = await callStringFunction(fnStart.toString(), 3)
+    expect(result).toEqual(9)
+  })
+})


### PR DESCRIPTION
This method allow to evaluate a function in worker context, without
having to declare a method in ContentScript before.

Example:

```javascript
const url = await this.evaluateInWorker(() => document.location.href)
```

This may of course be a little less optimized than declaring a method
before, but it is easier to follow I think.

This method can take :
 - normal functions
 - arrow function

Function returning a Promise will be awaited

```javascript
const result = await this.evaluateInWorker(() => {
  return new Promise(resolve =>
    window.setTimeout(() => resolve(window.document.location.href), 1000)
  )
})
```

Async function are not handled yet because of a babel transform problem
at the moment.
