### PR TITLE
feat: Be able to pass COZY_URL for konnector-dev

### DIFF
--- a/packages/cozy-jobs-cli/README.md
+++ b/packages/cozy-jobs-cli/README.md
@@ -22,6 +22,7 @@ You can use `COZY_URL` to connect to another cozy.
 - A token will be generated (`.token.json`) the first time to grant access to `cozy-konnector-dev`, and you may need to delete it and regenerate it again if expired.
 - Be aware that if you make a change in the application manifest, you must regenerate the token (deleting it if necessary) ([see the issue](https://github.com/konnectors/libs/issues/701)).
 
+You can use `COZY_URL` to connect to another cozy.
 ### `cozy-konnector-standalone`
 
 - Provides `COZY_CREDENTIALS` to the locally running connector from `konnector-dev-config.json` (which is created if it does not exist)

--- a/packages/cozy-jobs-cli/src/konnector-dev.js
+++ b/packages/cozy-jobs-cli/src/konnector-dev.js
@@ -5,7 +5,7 @@ const config = require('./init-konnector-config')()
 const injectDevAccount = require('./inject-dev-account')
 const ArgumentParser = require('argparse').ArgumentParser
 
-process.env.COZY_URL = config.COZY_URL
+process.env.COZY_URL = process.env.COZY_URL || config.COZY_URL
 if (config.COZY_PARAMETERS) {
   process.env.COZY_PARAMETERS = JSON.stringify(config.COZY_PARAMETERS)
 }


### PR DESCRIPTION
We were not able to bypass the default COZY_URL without updating the `.json` after the creation.

Now, we can call cozy-konnector-dev with a COZY_URL in order to set the right cozy url.