### PR TITLE
feat: Download files progressively only when needed 

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -104,14 +104,6 @@ const saveFiles = async (client, entries, folderPath, options) => {
     existingFilesIndex: options.existingFilesIndex
   }
 
-  if (options.validateFileContent) {
-    if (options.validateFileContent === true) {
-      saveOptions.validateFileContent = defaultValidateFileContent
-    } else if (typeof options.validateFileContent === 'function') {
-      saveOptions.validateFileContent = options.validateFileContent
-    }
-  }
-
   noMetadataDeduplicationErrors(saveOptions)
 
   let savedFiles = 0
@@ -315,14 +307,6 @@ async function createFile(client, entry, options, method, file) {
       await removeFile(client, fileDocument)
       throw new Error('BAD_DOWNLOADED_FILE')
     }
-
-    if (
-      options.validateFileContent &&
-      !(await options.validateFileContent(fileDocument))
-    ) {
-      await removeFile(client, fileDocument)
-      throw new Error('BAD_DOWNLOADED_FILE')
-    }
   }
 
   return fileDocument
@@ -468,14 +452,6 @@ function calculateFileKey(entry, fileIdAttributes) {
 
 function defaultValidateFile(fileDocument) {
   return checkFileSize(fileDocument)
-}
-
-async function defaultValidateFileContent(fileDocument) {
-  if (!defaultValidateFile(fileDocument)) {
-    log.warn('Wrong file type from content')
-    return false
-  }
-  return true
 }
 
 function sanitizeEntry(entry) {

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -10,6 +10,8 @@ const log = Minilog('saveFiles')
  * @property {string} [fileurl] - url where to download the corresponding file
  * @property {string} [filename] - name of the file
  * @property {string | ArrayBuffer} [filestream] - name of the file
+ * @property {boolean} [_cozy_file_to_create] - Internal use to count the number of files to download
+ * @property {object} [fileAttributes] - metadata attributes to add to the resulting file object
  */
 
 /**
@@ -92,6 +94,7 @@ const saveFiles = async (client, entries, folderPath, options = {}) => {
     shouldReplaceFile: options.shouldReplaceFile,
     validateFile: options.validateFile || defaultValidateFile,
     downloadAndFormatFile: options.downloadAndFormatFile,
+    qualificationLabel: options.qualificationLabel,
     sourceAccountOptions: {
       sourceAccount: options.sourceAccount,
       sourceAccountIdentifier: options.sourceAccountIdentifier
@@ -156,6 +159,17 @@ const saveFile = async function (client, entry, options) {
   let file = options.existingFilesIndex.get(
     calculateFileKey(entry, options.fileIdAttributes)
   )
+
+  if (options.qualificationLabel) {
+    if (!entry.fileAttributes) {
+      entry.fileAttributes = {}
+    }
+    if (!entry.fileAttributes.metadata) {
+      entry.fileAttributes.metadata = {}
+    }
+    entry.fileAttributes.metadata.qualification =
+      models.document.Qualification.getByLabel(options.qualificationLabel)
+  }
 
   if (entry.fileurl && !file && options.downloadAndFormatFile) {
     const downloadedEntry = await options.downloadAndFormatFile(entry)

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -7,17 +7,27 @@ import retry from 'bluebird-retry'
 const log = Minilog('saveFiles')
 
 const saveFiles = async (client, entries, folderPath, options = {}) => {
-  if (!entries || entries.length === 0) {
+  if (!entries) {
+    throw new Error('Savefiles : No list of files given')
+  }
+  if (entries.length === 0) {
     log.warn('No file to download')
   }
+  if (!options.manifest) {
+    throw new Error('Savefiles : no manifest')
+  }
   if (!options.sourceAccount) {
-    log.warn('There is no sourceAccount given to saveFiles')
+    throw new Error('Savefiles : no sourceAccount')
   }
   if (!options.sourceAccountIdentifier) {
-    log.warn('There is no sourceAccountIdentifier given to saveFiles')
+    throw new Error('Savefiles : no sourceAccountIdentifier')
   }
   if (!client) {
-    throw new Error('No cozy-client instance given')
+    throw new Error('Savefiles : No cozy-client instance given')
+  }
+
+  if (!options.fileIdAttributes) {
+    throw new Error('Savefiles : No fileIdAttributes')
   }
 
   const saveOptions = {
@@ -43,7 +53,7 @@ const saveFiles = async (client, entries, folderPath, options = {}) => {
     }
   }
 
-  noMetadataDeduplicationWarning(saveOptions)
+  noMetadataDeduplicationErrors(saveOptions)
 
   const canBeSaved = entry => entry.filestream
 
@@ -154,29 +164,17 @@ const saveEntry = async function (client, entry, options) {
   return entry
 }
 
-function noMetadataDeduplicationWarning(options) {
+function noMetadataDeduplicationErrors(options) {
   const fileIdAttributes = options.fileIdAttributes
   if (!fileIdAttributes) {
-    log.warn(
-      'No deduplication key is defined, file deduplication will be based on file path'
+    throw new Error(
+      'Savefiles : No deduplication key is defined, file deduplication will be based on file path'
     )
   }
 
   const slug = get(options, 'manifest.slug')
   if (!slug) {
-    log.warn(
-      'No slug is defined for the current connector, file deduplication will be based on file path'
-    )
-  }
-
-  const sourceAccountIdentifier = get(
-    options,
-    'sourceAccountOptions.sourceAccountIdentifier'
-  )
-  if (!sourceAccountIdentifier) {
-    log.warn(
-      'No sourceAccountIdentifier is defined in options, file deduplication will be based on file path'
-    )
+    throw new Error('Savefiles : No slug is defined for the current connector')
   }
 }
 

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -1,7 +1,9 @@
+// @ts-check
 import Minilog from '@cozy/minilog'
 import get from 'lodash/get'
 import omit from 'lodash/omit'
 import retry from 'bluebird-retry'
+import { models } from 'cozy-client'
 
 const log = Minilog('saveFiles')
 
@@ -54,9 +56,9 @@ const log = Minilog('saveFiles')
  * @param {Array<saveFilesEntry>} entries - file entries
  * @param {string} folderPath - path to the destination folder
  * @param {saveFilesOptions} options - saveFiles options
- * @returns {Array<saveFilesEntry>} - resulting entries
+ * @returns {Promise<Array<saveFilesEntry>>} - resulting entries
  */
-const saveFiles = async (client, entries, folderPath, options = {}) => {
+const saveFiles = async (client, entries, folderPath, options) => {
   if (!entries) {
     throw new Error('Savefiles : No list of files given')
   }
@@ -121,7 +123,7 @@ const saveFiles = async (client, entries, folderPath, options = {}) => {
 
     if (!entry.filename) {
       log.warn('Missing filename property, entry is ignored')
-      return
+      continue
     }
     const folderPath = await getOrCreateDestinationPath(
       client,
@@ -489,6 +491,15 @@ function attachFileToEntry(entry, fileDocument) {
   return entry
 }
 
+/**
+ * Get the full path of a given file, from it's folder path and file or entry
+ *
+ * @param {Object} arg - arg option object
+ * @param {import('cozy-client/types/types').FileDocument} [arg.file] - io.cozy.files object
+ * @param {saveFilesEntry} [arg.entry] - saveFiles entry
+ * @param {saveFileOptions} arg.options - io.cozy.files object
+ * @returns {string | undefined} - file full path
+ */
 function getFilePath({ file, entry, options }) {
   const folderPath = options.folderPath
   if (file) {

--- a/packages/cozy-clisk/src/launcher/saveFiles.spec.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.spec.js
@@ -1,18 +1,116 @@
 import saveFiles from './saveFiles'
 
 describe('saveFiles', function () {
-  it('should save a file without subPath', async () => {
+  it('should not download a file if the file is already present', async () => {
+    const fileDocument = {
+      _type: 'io.cozy.files',
+      type: 'file',
+      data: 'already present file content',
+      dirId: '/test/folder/path',
+      name: 'old file name.txt',
+      cozyMetadata: {
+        sourceAccount: 'testsourceaccount',
+        sourceAccountIdentifier: 'testsourceaccountidentifier'
+      },
+      metadata: {
+        fileIdAttributes: 'old file name.txt'
+      }
+    }
+    const existingFilesIndex = new Map([['old file name.txt', fileDocument]])
+    const client = {
+      save: jest.fn(),
+      collection: () => ({
+        statByPath: jest.fn().mockImplementation(path => {
+          return { data: { _id: path } }
+        })
+      })
+    }
+
+    const downloadAndFormatFile = jest.fn()
+
+    const document = {
+      fileurl: 'https://myfile.txt',
+      filename: 'old file name.txt'
+    }
+    const result = await saveFiles(client, [document], '/test/folder/path', {
+      manifest: {
+        slug: 'testslug'
+      },
+      sourceAccount: 'testsourceaccount',
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      fileIdAttributes: ['filename'],
+      existingFilesIndex,
+      downloadAndFormatFile
+    })
+
+    expect(downloadAndFormatFile).not.toHaveBeenCalled()
+
+    expect(result).toStrictEqual([
+      {
+        ...document,
+        fileDocument
+      }
+    ])
+  })
+  it('should download a file with fileurl and without filestream', async () => {
     const client = {
       save: jest.fn().mockImplementation(doc => ({
         data: doc
       })),
       collection: () => ({
         statByPath: jest.fn().mockImplementation(path => {
-          if (path === '/test/folder/path/file name.txt') {
-            return { data: null }
-          } else {
-            return { data: { _id: path } }
-          }
+          return { data: { _id: path } }
+        })
+      })
+    }
+
+    const downloadAndFormatFile = jest.fn().mockResolvedValue({
+      filestream: 'downloaded file content'
+    })
+
+    const document = {
+      fileurl: 'https://myfile.txt',
+      filename: 'file name.txt'
+    }
+    const result = await saveFiles(client, [document], '/test/folder/path', {
+      manifest: {
+        slug: 'testslug'
+      },
+      sourceAccount: 'testsourceaccount',
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      fileIdAttributes: ['filename'],
+      existingFilesIndex: new Map(),
+      downloadAndFormatFile
+    })
+
+    const fileDocument = {
+      _type: 'io.cozy.files',
+      type: 'file',
+      data: 'downloaded file content',
+      dirId: '/test/folder/path',
+      name: 'file name.txt',
+      sourceAccount: 'testsourceaccount',
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      metadata: {
+        fileIdAttributes: 'file name.txt'
+      }
+    }
+    expect(client.save).toHaveBeenCalledWith(fileDocument)
+    expect(result).toStrictEqual([
+      {
+        ...document,
+        fileDocument
+      }
+    ])
+  })
+  it('should save a file with filestream without subPath', async () => {
+    const client = {
+      save: jest.fn().mockImplementation(doc => ({
+        data: doc
+      })),
+      collection: () => ({
+        statByPath: jest.fn().mockImplementation(path => {
+          return { data: { _id: path } }
         })
       })
     }
@@ -25,7 +123,9 @@ describe('saveFiles', function () {
         slug: 'testslug'
       },
       sourceAccount: 'testsourceaccount',
-      sourceAccountIdentifier: 'testsourceaccountidentifier'
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      fileIdAttributes: ['filename'],
+      existingFilesIndex: new Map()
     })
     const fileDocument = {
       _type: 'io.cozy.files',
@@ -34,10 +134,63 @@ describe('saveFiles', function () {
       dirId: '/test/folder/path',
       name: 'file name.txt',
       sourceAccount: 'testsourceaccount',
-      sourceAccountIdentifier: 'testsourceaccountidentifier'
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      metadata: {
+        fileIdAttributes: 'file name.txt'
+      }
     }
     expect(client.save).toHaveBeenCalledWith(fileDocument)
     expect(result).toStrictEqual([
+      {
+        ...document,
+        fileDocument
+      }
+    ])
+  })
+  it('should save a file with qualification label', async () => {
+    const client = {
+      save: jest.fn().mockImplementation(doc => ({
+        data: doc
+      })),
+      collection: () => ({
+        statByPath: jest.fn().mockImplementation(path => {
+          return { data: { _id: path } }
+        })
+      })
+    }
+    const document = {
+      filestream: 'filestream content',
+      filename: 'file name.txt'
+    }
+    const result = await saveFiles(client, [document], '/test/folder/path', {
+      manifest: {
+        slug: 'testslug'
+      },
+      sourceAccount: 'testsourceaccount',
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      fileIdAttributes: ['filename'],
+      existingFilesIndex: new Map(),
+      qualificationLabel: 'energy_invoice'
+    })
+    const fileDocument = {
+      _type: 'io.cozy.files',
+      type: 'file',
+      data: 'filestream content',
+      dirId: '/test/folder/path',
+      name: 'file name.txt',
+      sourceAccount: 'testsourceaccount',
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      metadata: {
+        fileIdAttributes: 'file name.txt',
+        qualification: {
+          label: 'energy_invoice',
+          purpose: 'invoice',
+          sourceCategory: 'energy'
+        }
+      }
+    }
+    expect(client.save).toHaveBeenCalledWith(fileDocument)
+    expect(result).toEqual([
       {
         ...document,
         fileDocument
@@ -52,11 +205,7 @@ describe('saveFiles', function () {
       collection: () => ({
         createDirectoryByPath: jest.fn(),
         statByPath: jest.fn().mockImplementation(path => {
-          if (path === '/test/folder/path/file name.txt') {
-            return { data: null }
-          } else {
-            return { data: { _id: path } }
-          }
+          return { data: { _id: path } }
         })
       })
     }
@@ -70,7 +219,9 @@ describe('saveFiles', function () {
       },
       subPath: 'subPath',
       sourceAccount: 'testsourceaccount',
-      sourceAccountIdentifier: 'testsourceaccountidentifier'
+      sourceAccountIdentifier: 'testsourceaccountidentifier',
+      fileIdAttributes: ['filename'],
+      existingFilesIndex: new Map()
     })
     expect(client.save).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Now the launcher will only have to call saveFiles directly for all the
given files,  which will avoid to download all the files before calling
saveFiles. (PR in flagship app to follow)

The downloadAndFormatFile option callback has been added to allow
saveFiles to download the corresponding file in the worker when needed

For optimization, an index of already downloaded files is created on
each call to saveFiles. Then, when saveFiles is called with multiple
entries, the need to download a file will be detected quickly.

Also clean some code and added jsdoc as much as possible now.