### PR TITLE
feat: Add sourceAccountIdentifer in addData

### DIFF
--- a/packages/cozy-clisk/src/launcher/addData.js
+++ b/packages/cozy-clisk/src/launcher/addData.js
@@ -12,13 +12,28 @@ const log = Minilog('addData')
  * @param {string} doctype : the doctype where you want to save data (ex: 'io.cozy.bills')
  * @param {object} options : options object
  * @param {import('cozy-client/types/CozyClient').default} options.client CozyClient instance
+ * @param {string} options.sourceAccountIdentifier : unique identifier of the user website account
  */
 export default async (entries, doctype, options) => {
   const client = options?.client
+  if (!client) {
+    throw new Error('addData: called without any client in options')
+  }
+
+  if (!options?.sourceAccountIdentifier) {
+    throw new Error(
+      'addData: called without any sourceAccountIdentifier in options'
+    )
+  }
+
   const result = []
   for (const entry of entries) {
     log.debug('Adding entry', entry)
-    const doc = await client.save({ ...entry, _type: doctype })
+    const doc = await client.save({
+      ...entry,
+      _type: doctype,
+      sourceAccountIdentifier: options.sourceAccountIdentifier
+    })
     const dbEntry = doc.data
     entry._id = dbEntry._id
     result.push(dbEntry)

--- a/packages/cozy-clisk/src/launcher/addData.spec.js
+++ b/packages/cozy-clisk/src/launcher/addData.spec.js
@@ -1,0 +1,34 @@
+import addData from './addData'
+
+describe('addData', function () {
+  it('should save data and add sourceAccountIdentifier', async () => {
+    const client = {
+      save: jest.fn().mockImplementation(doc => ({
+        data: {
+          ...doc,
+          _id: 'testid',
+          _rev: 'testrev'
+        }
+      }))
+    }
+    const bills = [{ amount: 12 }]
+    const result = await addData(bills, 'io.cozy.bills', {
+      client,
+      sourceAccountIdentifier: 'test@login'
+    })
+    expect(client.save).toHaveBeenCalledWith({
+      amount: 12,
+      sourceAccountIdentifier: 'test@login',
+      _type: 'io.cozy.bills'
+    })
+    expect(result).toStrictEqual([
+      {
+        amount: 12,
+        sourceAccountIdentifier: 'test@login',
+        _type: 'io.cozy.bills',
+        _id: 'testid',
+        _rev: 'testrev'
+      }
+    ])
+  })
+})


### PR DESCRIPTION
Now addData will also add the current sourceAccountIdentifer to any
document.

This will allow more optimized request on bills especially when requesting
all the existing documents imported by a konnector with given
sourceAccountIdentifier.
