### PR TITLE
feat: Add queryAll method to content script

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -353,6 +353,29 @@ export default class ContentScript {
   }
 
   /**
+   * Query all the documents corresponding to the given query object. The client with permissions corresponding
+   * to the current konnector manifest will be used.
+   *
+   * @param {import("cozy-client").QueryDefinition} queryDefinition - CozyClient query definition object
+   * @param {import('cozy-client/types/types').QueryOptions} options - CozyClient query options
+   * @returns {Promise<import('cozy-client/types/types').QueryResult>}
+   */
+  async queryAll(queryDefinition, options) {
+    this.onlyIn(PILOT_TYPE, 'queryAll')
+    if (!this.bridge) {
+      throw new Error(
+        'No bridge is defined, you should call ContentScript.init before using this method'
+      )
+    }
+
+    return await this.bridge.call(
+      'queryAll',
+      queryDefinition.toDefinition(),
+      options
+    )
+  }
+
+  /**
    * Bridge to the saveBills method from the launcher.
    * - it first saves the files
    * - then saves bills linked to corresponding files

--- a/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
@@ -1,6 +1,37 @@
 import ContentScript, { PILOT_TYPE } from './ContentScript'
+import { Q } from 'cozy-client'
 
 describe('ContentScript', () => {
+  describe('queryAll', () => {
+    it('should convert the given query definition to a serializable object', async () => {
+      const contentScript = new ContentScript()
+      contentScript.setContentScriptType(PILOT_TYPE)
+      contentScript.bridge = {
+        call: jest.fn()
+      }
+      await contentScript.queryAll(
+        Q('io.cozy.files').where({
+          cozyMetadata: {
+            sourceAccountIdentifier: 'testidentifier',
+            createdByApp: 'testslug'
+          }
+        }),
+        { as: 'testfilesrequest' }
+      )
+      expect(contentScript.bridge.call).toHaveBeenCalledWith(
+        'queryAll',
+        expect.objectContaining({
+          selector: {
+            cozyMetadata: {
+              sourceAccountIdentifier: 'testidentifier',
+              createdByApp: 'testslug'
+            }
+          }
+        }),
+        { as: 'testfilesrequest' }
+      )
+    })
+  })
   describe('runInWorker', () => {
     const contentScript = new ContentScript()
     contentScript.setContentScriptType(PILOT_TYPE)


### PR DESCRIPTION
This method will follow the same interface as CozyClient.queryAll

ex :

```javascript
import { Q } from 'cozy-client/dist/queries/dsl' // to avoid to have to include all cozy-client dependencies in the konnector
const result = await this.queryAll(Q('io.cozy.files').where({
  cozyMetadata: {
    sourceAccountIdentifier: 'testsourceaccountidentifier',
    createdByApp: 'appslug'
  }
}), {as: 'request alias'})
```

To be serializable, the QueryDefinition object transformed to a
javascript object with QueryDefinition.toDefinition and will be
transformed back to QueryDefinition object on the flagship app side.

The addition of 'cozy-client/dist/queries/dsl' in konnector is quite
heavy for the konnector because of lodash dependencies (from 188Ko to
307Ko) for the built version of the template konnector. We could
compensate this with the addition of the production mode in the webpack
configuration (307Ko -> 99Ko but with a longer build)

linked to https://github.com/cozy/cozy-flagship-app/pull/850 for the flagship app side
