### PR TITLE
feat: Add blockWorkerInteractions command in content script

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -529,6 +529,26 @@ export default class ContentScript {
     await this.setWorkerState({ url })
   }
 
+  async blockWorkerInteractions() {
+    this.onlyIn(PILOT_TYPE, 'blockWorkerInteractions')
+    if (!this.bridge) {
+      throw new Error(
+        'No bridge is defined, you should call ContentScript.init before using this method'
+      )
+    }
+    await this.bridge.call('blockWorkerInteractions')
+  }
+
+  async unblockWorkerInteractions() {
+    this.onlyIn(PILOT_TYPE, 'unblockWorkerInteractions')
+    if (!this.bridge) {
+      throw new Error(
+        'No bridge is defined, you should call ContentScript.init before using this method'
+      )
+    }
+    await this.bridge.call('unblockWorkerInteractions')
+  }
+
   /**
    * Make sure that the connector is authenticated to the website.
    * If not, show the login webview to the user to let her/him authenticated.


### PR DESCRIPTION
It is now possible to block user interactions on the worker.
This is needed when the user has validated a login form but when the
konnector does not knoow yet if the login is successful. This avoids
unwanted user interactions which may alter the konnector execution.

Just call :

```javascript
this.blockWorkerInteractions()
this.unblockWorkerInteractions()
```

from the content script
