### PR TITLE
feat: Add a onWorkerReady callback to the content script

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -133,9 +133,14 @@ export default class ContentScript {
         'debug',
         `window.beforeunload detected with previous url : ${document.location}`
       )
-
-    this.bridge.emit('workerReady')
   }
+
+  /**
+   * This method is called when the worker is ready on the current page. This is a good place to
+   * subscribe to dom events for examples. These subscriptions will be replayed on each worker page
+   * reload
+   */
+  onWorkerReady() {}
 
   /**
    * Set the ContentScript type. This is usefull to know which webview is the pilot or the worker
@@ -145,6 +150,10 @@ export default class ContentScript {
   async setContentScriptType(contentScriptType) {
     this.contentScriptType = contentScriptType
     log.info(`I am the ${contentScriptType}`)
+
+    if (contentScriptType === WORKER_TYPE) {
+      this.onWorkerReady()
+    }
   }
 
   /**


### PR DESCRIPTION
This method of the content script will be called each time the worker
page is reloaded and when the worker bridge is ready to take commands.

This will be useful to subscribe to page events and redirect it to pilot
methods.

Ex :

```javascript
  onWorkerReady() {
    const button = document.querySelector('input[type=submit]')
    if (button) {
      button.addEventListener('click', () =>
        this.bridge.emit('workerEvent', 'loginSubmit')
      )
    }
  }
```

The `workerEvent` event will be sent directly to the pilot and here the
pilot will be able to call `this.blockWorkerInteractions` for example.
