### PR TITLE
fix: Duplicated identities

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveIdentity.spec.js
+++ b/packages/cozy-clisk/src/launcher/saveIdentity.spec.js
@@ -60,4 +60,40 @@ describe('saveIdentity', function () {
       _rev: 'testrev'
     })
   })
+
+  it('should update identity with previous identity metadata', async () => {
+    const identity = {
+      email: 'test2@mail.com'
+    }
+
+    client.query.mockResolvedValue({
+      data: [
+        {
+          _id: 'testid',
+          _rev: 'testrev',
+          _type: 'io.cozy.identities',
+          contact: {
+            email: 'testprevious@mail.com'
+          },
+          cozyMetadata: {
+            createdByApp: 'testslug'
+          },
+          identifier: 'testSourceAccountIdentifier'
+        }
+      ]
+    })
+
+    await saveIdentity(identity, 'testSourceAccountIdentifier', { client })
+
+    expect(client.save).toHaveBeenCalledWith({
+      contact: identity,
+      identifier: 'testSourceAccountIdentifier',
+      cozyMetadata: {
+        createdByApp: 'testslug'
+      },
+      _type: 'io.cozy.identities',
+      _id: 'testid',
+      _rev: 'testrev'
+    })
+  })
 })


### PR DESCRIPTION
With the same konnector and with the same sourceAccountIdentifier, a new
identity was created once in two run of the connector.

This was caused by the loss of the `cozyMetadata.createdByApp` attribute
when an identity was updated.

Now the cozyMetadata attributes are kept on each run of the connector

Will need to update the flagship app with the next version of cozy-clisk
