### PR TITLE
fix: Do not send page message on ContentScript file import

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -19,7 +19,6 @@ const DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT = 30 * s
 export const PILOT_TYPE = 'pilot'
 export const WORKER_TYPE = 'worker'
 
-sendPageMessage('NEW_WORKER_INITIALIZING')
 if (window?.addEventListener) {
   // allows cozy-clisk to be embedded in other envs (react-native, jest)
   window.addEventListener('load', () => {
@@ -32,6 +31,7 @@ if (window?.addEventListener) {
 
 export default class ContentScript {
   constructor() {
+    sendPageMessage('NEW_WORKER_INITIALIZING')
     const logDebug = message => this.log('debug', message)
     const wrapTimerDebug = wrapTimerFactory({ logFn: logDebug })
     const logInfo = message => this.log('info', message)


### PR DESCRIPTION
This caused an error message : "No
window.ReactNativeWebview.postMessage" when importing cozy-clisk in the
flagship app.

Now the message is sent on ContentScript class instanciation, which
looks fast enough.
