### PR TITLE
feat(clisk): Force log timestamp to milliseconds

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -523,7 +523,7 @@ export default class ContentScript {
     if (!allowedLevels.includes(level)) {
       newLevel = 'debug'
     }
-    const now = new Date()
+    const now = new Date().toISOString()
     this.bridge?.emit('log', {
       timestamp: now,
       level: newLevel,


### PR DESCRIPTION
For now, we will simply add the milliseconds.

This PR for the string to be like 2023-07-22T14:48:00.000Z