### PR TITLE
fix: Declare waitForNotAuthenticated

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -211,15 +211,21 @@ export default class ContentScript {
     this.onlyIn(WORKER_TYPE, 'waitForNotAuthenticated')
     const timeout = options.timeout || DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT
     const interval = options.interval || 1000
-    await waitFor(() => !this.checkAuthenticated.bind(this)(), {
-      interval,
-      timeout: {
-        milliseconds: timeout,
-        message: new TimeoutError(
-          `waitForNotAuthenticated timed out after ${timeout}ms`
-        )
+    await waitFor(
+      async () => {
+        const authenticated = await this.checkAuthenticated.bind(this)()
+        return !authenticated
+      },
+      {
+        interval,
+        timeout: {
+          milliseconds: timeout,
+          message: new TimeoutError(
+            `waitForNotAuthenticated timed out after ${timeout}ms`
+          )
+        }
       }
-    })
+    )
     return true
   }
 

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -181,7 +181,7 @@ export default class ContentScript {
    * @returns {Promise.<true>} : if authenticated
    * @throws {TimeoutError}: TimeoutError from p-wait-for package if timeout expired
    */
-  async waitForAuthenticated(options) {
+  async waitForAuthenticated(options = {}) {
     this.onlyIn(WORKER_TYPE, 'waitForAuthenticated')
     const timeout = options.timeout || DEFAULT_LOGIN_TIMEOUT
     const interval = options.interval || 1000
@@ -207,7 +207,7 @@ export default class ContentScript {
    * @returns {Promise.<true>} : if not authenticated
    * @throws {TimeoutError}: TimeoutError from p-wait-for package if timeout expired
    */
-  async waitForNotAuthenticated(options) {
+  async waitForNotAuthenticated(options = {}) {
     this.onlyIn(WORKER_TYPE, 'waitForNotAuthenticated')
     const timeout = options.timeout || DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT
     const interval = options.interval || 1000

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -41,6 +41,10 @@ export default class ContentScript {
     this.getUserDataFromWebsite = wrapTimerInfo(this, 'getUserDataFromWebsite')
     this.fetch = wrapTimerInfo(this, 'fetch')
     this.waitForAuthenticated = wrapTimerDebug(this, 'waitForAuthenticated')
+    this.waitForNotAuthenticated = wrapTimerDebug(
+      this,
+      'waitForNotAuthenticated'
+    )
     this.runInWorker = wrapTimerDebug(this, 'runInWorker', {
       suffixFn: args => args?.[0]
     })
@@ -99,6 +103,7 @@ export default class ContentScript {
       'ensureNotAuthenticated',
       'checkAuthenticated',
       'waitForAuthenticated',
+      'waitForNotAuthenticated',
       'waitForElementNoReload',
       'getUserDataFromWebsite',
       'fetch',


### PR DESCRIPTION
- declare waitForNotAuthenticated to be able to call it in the worker
- default value for waitForAuthenticated* methods to avoid regression for existing konnectors
- do not return the negation of a promise but await the result
