### PR TITLE
fix: Add specfic error message when file is empty in saveFiles

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -282,6 +282,10 @@ async function createFile(client, entry, options, method, file) {
 
   const toCreate = entry.filestream
 
+  if (toCreate == undefined) {
+    throw new Error('saveFiles got undefined file content (entry.filestream)')
+  }
+
   let fileDocument
   if (method === 'create') {
     const clientResponse = await client.save({

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -4,6 +4,7 @@ import get from 'lodash/get'
 import omit from 'lodash/omit'
 import retry from 'bluebird-retry'
 import { models } from 'cozy-client'
+import { dataUriToArrayBuffer } from '../libs/utils'
 
 const log = Minilog('saveFiles')
 
@@ -169,6 +170,16 @@ const saveFile = async function (client, entry, options) {
     const downloadedEntry = await options.downloadAndFormatFile(entry)
     entry.filestream = downloadedEntry.filestream
     delete entry.fileurl
+  }
+
+  if (entry.dataUri) {
+    const { arrayBuffer } = dataUriToArrayBuffer(entry.dataUri)
+    if (arrayBuffer) {
+      entry.filestream = arrayBuffer
+      delete entry.dataUri
+    } else {
+      throw new Error('saveFiles: failed to convert dataUri to filestream')
+    }
   }
   let shouldReplace = false
   if (file) {

--- a/packages/cozy-clisk/src/libs/utils.js
+++ b/packages/cozy-clisk/src/libs/utils.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef ArrayBufferWithContentType
+ * @property {string} contentType - dataUri included content type
+ * @property {ArrayBuffer} arrayBuffer - resulting decoded data
+ */
+
+/**
+ * Converts a data URI string to an Array Buffer with its content Type
+ *
+ * @param {string} dataURI - data URI string containing content type and base64 encoded data
+ * @returns {ArrayBufferWithContentType} : array buffer with content type
+ */
+export const dataUriToArrayBuffer = dataURI => {
+  const [contentType, base64String] = dataURI
+    .match(/^data:(.*);base64,(.*)$/)
+    .slice(1)
+  const byteString = global.atob(base64String)
+  const arrayBuffer = new ArrayBuffer(byteString.length)
+  const ia = new Uint8Array(arrayBuffer)
+  for (let i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i)
+  }
+  return { contentType, arrayBuffer }
+}


### PR DESCRIPTION
And not from the flagship app anymore.

This allows to do this conversion :
- when downloading files
- when the konnector gives a dataUri directly

See also : https://github.com/cozy/cozy-flagship-app/pull/895
