### PR TITLE
fix: Regression on regular file download

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -168,7 +168,7 @@ const saveFile = async function (client, entry, options) {
 
   if (entry.fileurl && !file && options.downloadAndFormatFile) {
     const downloadedEntry = await options.downloadAndFormatFile(entry)
-    entry.filestream = downloadedEntry.filestream
+    entry.dataUri = downloadedEntry.dataUri
     delete entry.fileurl
   }
 

--- a/packages/cozy-clisk/src/launcher/saveFiles.spec.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.spec.js
@@ -68,8 +68,12 @@ describe('saveFiles', function () {
       })
     }
 
+    dataUriToArrayBuffer.mockImplementation(dataUri => ({
+      arrayBuffer: dataUri + ' arrayBuffer'
+    }))
+
     const downloadAndFormatFile = jest.fn().mockResolvedValue({
-      filestream: 'downloaded file content'
+      dataUri: 'downloaded file content'
     })
 
     const document = {
@@ -90,7 +94,7 @@ describe('saveFiles', function () {
     const fileDocument = {
       _type: 'io.cozy.files',
       type: 'file',
-      data: 'downloaded file content',
+      data: 'downloaded file content arrayBuffer',
       dirId: '/test/folder/path',
       name: 'file name.txt',
       sourceAccount: 'testsourceaccount',


### PR DESCRIPTION
When the konnector just gives a fileurl to the launcher, the download of
the file would fail because of a wrong filestream attribute.

And the unit test was wrong too

Will need to update cozy-clisk on flagship app.
