### PR TITLE
fix: Remove allowed log level check

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -554,21 +554,16 @@ export default class ContentScript {
    * @param {string} message : the log message
    */
   log(level, message) {
-    let newLevel = level
-    const allowedLevels = ['debug', 'info', 'warn', 'error']
     if (!message) {
       log.warn(
         `you are calling log without message, use log(level,message) instead`
       )
       return
     }
-    if (!allowedLevels.includes(level)) {
-      newLevel = 'debug'
-    }
     const now = new Date().toISOString()
     this.bridge?.emit('log', {
       timestamp: now,
-      level: newLevel,
+      level,
       msg: message
     })
   }


### PR DESCRIPTION
We will check if the log level is allowed in flagship app since it needs
the same check and we don't want to do the same check twice
