### PR TITLE
feat: Allow launcher to fetch debug data from the worker

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -114,6 +114,7 @@ export default class ContentScript {
       'getCookiesByDomain',
       'getCookieByDomainAndName',
       'downloadFileInWorker',
+      'getDebugData',
       'getCliskVersion',
       'checkForElement',
       'evaluate'
@@ -380,6 +381,13 @@ export default class ContentScript {
       entry.dataUri = await blobToBase64(entry.blob)
     }
     return entry.dataUri
+  }
+
+  async getDebugData() {
+    return {
+      url: window.location.href,
+      html: window.document.documentElement.outerHTML
+    }
   }
   /**
    * Bridge to the saveFiles method from the launcher.


### PR DESCRIPTION
It gets the following data :

- current url
- current dom serialized as string

This will be useful to allow the launcher to fetch data when an error
occurs in the execution of the konnector
