### PR TITLE
fix: Scope issue

### DIFF
--- a/packages/cozy-jobs-cli/src/manifest.js
+++ b/packages/cozy-jobs-cli/src/manifest.js
@@ -9,8 +9,16 @@ module.exports = {
     // convert the permissions into scopes
     let scopes = []
     for (let key in permissions) {
-      scopes.push(permissions[key].type)
+      let type = permissions[key].type
+      let verbs = permissions[key].verbs
+
+      if (verbs && verbs.length > 0) {
+        scopes.push(type + ':' + verbs.join(','))
+      } else {
+        scopes.push(type)
+      }
     }
+
     log('debug', scopes, 'scopes found')
 
     return scopes

--- a/packages/cozy-jobs-cli/src/manifest.spec.js
+++ b/packages/cozy-jobs-cli/src/manifest.spec.js
@@ -1,0 +1,12 @@
+const { getScopes } = require('./manifest')
+
+describe('getScopes', () => {
+  test('getScopes', () => {
+    const scopes = getScopes('./tests/manifest-test.webapp')
+    expect(scopes).toEqual([
+      'io.cozy.files:GET,POST,PUT,PATCH',
+      'io.cozy.foo',
+      'io.cozy.bar:ALL'
+    ])
+  })
+})

--- a/packages/cozy-jobs-cli/tests/manifest-test.webapp
+++ b/packages/cozy-jobs-cli/tests/manifest-test.webapp
@@ -1,0 +1,23 @@
+{
+    "permissions": {
+        "files": {
+            "description": "Required for photo access",
+            "type": "io.cozy.files",
+            "verbs": [
+                "GET",
+                "POST",
+                "PUT",
+                "PATCH"
+            ]
+        },
+        "foo": {
+            "description": "barr",
+            "type": "io.cozy.foo"
+        },
+        "bar": {
+            "description": "a",
+            "type": "io.cozy.bar",
+            "verbs": ["ALL"]
+        }
+    }
+}


### PR DESCRIPTION
cozy-konnector-dev was not taking the "verbs" attribute to generate the OAuth client scope. The result was that when we launched a service by using:
```
yarn run cozy-konnector-dev -m build/manifest.webapp build/services/recurringPurposes/coachco2.js
```

the generated token has all the rights to the permissions and it was then working.

But when launching the service from the stack with:

```
cozy-stack services run XXXX
```

then it failed because we didn't had the right verbs to the manifest

Here, we fix this issue and cozy-konnector-dev is now reading the verbs in order to generate the right token.