### PR TITLE
feat: Now create destination folders before saving files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 packages/*/node_modules/*
+packages/*/.vscode/*
 yarn-error.log
 packages/*/dist/*
 .changelog/*

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -61,7 +61,11 @@ export default class ContentScript {
     this.clickAndWait = wrapTimerDebug(this, 'clickAndWait', {
       suffixFn: args => `${args?.[0]} ${args?.[1]}`
     })
-    this.saveFiles = wrapTimerDebug(this, 'saveFiles')
+    this.saveFiles = wrapTimerDebug(this, 'saveFiles', {
+      suffixFn: args => {
+        return `${args?.[0].length} files`
+      }
+    })
     this.saveBills = wrapTimerDebug(this, 'saveBills')
     this.getCredentials = wrapTimerDebug(this, 'getCredentials')
     this.saveCredentials = wrapTimerDebug(this, 'saveCredentials')
@@ -447,7 +451,7 @@ export default class ContentScript {
    */
   async saveFiles(entries, options) {
     this.onlyIn(PILOT_TYPE, 'saveFiles')
-    log.debug(entries, 'saveFiles input entries')
+    this.log('debug', `saveFiles ${entries.length} input entries`)
     const context = options.context
     log.debug(context, 'saveFiles input context')
 

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -25,7 +25,6 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @property {Array<string>} fileIdAttributes - List of entry attributes considered as unique deduplication key
  * @property {Function} log - Logging function coming from the Launcher
  * @property {string} [subPath] - subPath of the destination folder path where to put the downloaded file
- * @property {Function} [postProcess] - callback called after the file is download to further modify it
  * @property {string} [contentType] - will force the contentType of the file if any
  * @property {Function} [shouldReplaceFile] - Function which will define if the file should be replaced or not
  * @property {Function} [validateFile] - this function will check if the downloaded file is correct (by default, error if file size is 0)
@@ -41,7 +40,6 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @property {Array<string>} fileIdAttributes - List of entry attributes considered as unique deduplication key
  * @property {Function} log - Logging function coming from the Launcher
  * @property {string} [subPath] - subPath of the destination folder path where to put the downloaded file
- * @property {Function} [postProcess] - callback called after the file is download to further modify it
  * @property {string} [contentType] - will force the contentType of the file if any
  * @property {Function} [shouldReplaceFile] - Function which will define if the file should be replaced or not
  * @property {Function} [validateFile] - this function will check if the downloaded file is correct (by default, error if file size is 0)
@@ -111,7 +109,6 @@ const saveFiles = async (client, entries, folderPath, options) => {
     subPath: options.subPath,
     fileIdAttributes: options.fileIdAttributes,
     manifest: options.manifest,
-    postProcess: options.postProcess,
     contentType: options.contentType,
     shouldReplaceFile: options.shouldReplaceFile,
     validateFile: options.validateFile || defaultValidateFile,
@@ -330,9 +327,6 @@ const saveFile = async function (client, entry, options) {
     attachFileToEntry(resultEntry, createdFile)
 
     sanitizeEntry(resultEntry)
-    if (options.postProcess) {
-      await options.postProcess(entry)
-    }
   } catch (err) {
     if (err.message === 'MAIN_FOLDER_REMOVED') {
       throw err
@@ -731,7 +725,6 @@ function defaultValidateFile(fileDocument, options) {
 }
 
 function sanitizeEntry(entry) {
-  delete entry.fetchFile
   delete entry.requestOptions
   delete entry.filestream
   delete entry.shouldReplaceFile

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -107,6 +107,7 @@ const saveFiles = async (client, entries, folderPath, options) => {
         console.log(`${level}: saveFiles: ${label}: ${msg}`)
       }
     },
+    retry: options.retry,
     subPath: options.subPath,
     fileIdAttributes: options.fileIdAttributes,
     manifest: options.manifest,

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -56,7 +56,7 @@ import { dataUriToArrayBuffer } from '../libs/utils'
 /**
  * Saves the given files to the cozy stack
  *
- * @param {import('cozy-client/types/CozyClient')} client - CozyClient instance
+ * @param {import('cozy-client/types/CozyClient').default} client - CozyClient instance
  * @param {Array<saveFilesEntry>} entries - file entries
  * @param {string} folderPath - path to the destination folder
  * @param {saveFilesOptions} options - saveFiles options
@@ -192,7 +192,7 @@ const saveFiles = async (client, entries, folderPath, options) => {
  * errors.
  *
  * @param {object} options - Options object
- * @param {import('cozy-client/types/CozyClient')} options.client - CozyClient instance
+ * @param {import('cozy-client/types/CozyClient').default} options.client - CozyClient instance
  * @param {Array<saveFilesEntry>} options.entries - file entry
  * @param {saveFileOptions} options.options - saveFiles options
  * @param {string} options.folderPath - path to the destination folder
@@ -204,7 +204,6 @@ async function ensureAllDestinationFolders({
   folderPath,
   options
 }) {
-  // @ts-ignore Property 'collection' does not exist on type 'typeof CozyClient'.ts(2339)
   const fileCollection = client.collection('io.cozy.files')
 
   const pathsList = []
@@ -230,7 +229,7 @@ async function ensureAllDestinationFolders({
 /**
  * Saves a single file entry
  *
- * @param {import('cozy-client/types/CozyClient')} client - CozyClient instance
+ * @param {import('cozy-client/types/CozyClient').default} client - CozyClient instance
  * @param {saveFilesEntry} entry - file entry
  * @param {saveFileOptions} options - saveFiles options
  * @returns {Promise<saveFilesEntry>} - resulting file entry with file document
@@ -436,7 +435,7 @@ async function createFileWithFolderOnError(
 /**
  *
  * @param {object} options - options object
- * @param {import('cozy-client/types/CozyClient')} options.client - CozyClient instance
+ * @param {import('cozy-client/types/CozyClient').default} options.client - CozyClient instance
  * @param {saveFilesEntry} options.entry - saveFiles entry
  * @param {saveFileOptions} options.options - saveFiles options
  * @param {'create'|'updateById'} options.method - file creation method which will be used
@@ -479,7 +478,6 @@ async function createFile({ client, entry, options, method, file, dirId }) {
   let fileDocument
   const start = Date.now()
   if (method === 'create') {
-    // @ts-ignore Property 'save' does not exist on type 'typeof import("/home/doubleface/Workspace/connectors/libs/node_modules/cozy-client/types/CozyClient")'.ts(2339)
     const clientResponse = await client.save({
       _type: 'io.cozy.files',
       type: 'file',
@@ -489,7 +487,6 @@ async function createFile({ client, entry, options, method, file, dirId }) {
     fileDocument = clientResponse.data
   } else if (method === 'updateById') {
     options.log('debug', 'createFile', `replacing file for ${entry.filename}`)
-    // @ts-ignore Property 'save' does not exist on type 'typeof import("/home/doubleface/Workspace/connectors/libs/node_modules/cozy-client/types/CozyClient")'.ts(2339)
     const clientResponse = client.save({
       _id: file._id,
       _rev: file._rev,
@@ -598,7 +595,7 @@ const shouldReplaceFile = function (file, entry, options) {
 /**
  * Remove the given file
  *
- * @param {import('cozy-client/types/CozyClient')} client - CozyClient instance
+ * @param {import('cozy-client/types/CozyClient').default} client - CozyClient instance
  * @param {import('cozy-client/types/types').FileDocument} file - file to remove
  * @param {saveFileOptions} options - options object
  */
@@ -606,7 +603,6 @@ const removeFile = async function (client, file, options) {
   if (!client) {
     options.log('error', 'removeFile', 'No client, impossible to delete file')
   } else {
-    // @ts-ignore Property 'collection' does not exist on type 'CozyClient"
     await client.collection('io.cozy.files').deleteFilePermanently(file._id)
   }
 }

--- a/packages/cozy-clisk/src/launcher/saveFiles.spec.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.spec.js
@@ -44,7 +44,8 @@ describe('saveFiles', function () {
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
       existingFilesIndex,
-      downloadAndFormatFile
+      downloadAndFormatFile,
+      log: jest.fn()
     })
 
     expect(downloadAndFormatFile).not.toHaveBeenCalled()
@@ -88,7 +89,8 @@ describe('saveFiles', function () {
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
       existingFilesIndex: new Map(),
-      downloadAndFormatFile
+      downloadAndFormatFile,
+      log: jest.fn()
     })
 
     const fileDocument = {
@@ -138,7 +140,8 @@ describe('saveFiles', function () {
       sourceAccount: 'testsourceaccount',
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
-      existingFilesIndex: new Map()
+      existingFilesIndex: new Map(),
+      log: jest.fn()
     })
 
     const fileDocument = {
@@ -187,7 +190,8 @@ describe('saveFiles', function () {
       sourceAccount: 'testsourceaccount',
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
-      existingFilesIndex: new Map()
+      existingFilesIndex: new Map(),
+      log: jest.fn()
     })
     const fileDocument = {
       _type: 'io.cozy.files',
@@ -232,7 +236,8 @@ describe('saveFiles', function () {
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
       existingFilesIndex: new Map(),
-      qualificationLabel: 'energy_invoice'
+      qualificationLabel: 'energy_invoice',
+      log: jest.fn()
     })
     const fileDocument = {
       _type: 'io.cozy.files',
@@ -265,7 +270,6 @@ describe('saveFiles', function () {
         data: doc
       })),
       collection: () => ({
-        createDirectoryByPath: jest.fn(),
         statByPath: jest.fn().mockImplementation(path => {
           return { data: { _id: path } }
         })
@@ -283,7 +287,8 @@ describe('saveFiles', function () {
       sourceAccount: 'testsourceaccount',
       sourceAccountIdentifier: 'testsourceaccountidentifier',
       fileIdAttributes: ['filename'],
-      existingFilesIndex: new Map()
+      existingFilesIndex: new Map(),
+      log: jest.fn()
     })
     expect(client.save).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
And folders are created only for files which will be downloaded (this avoids creating empty folders when files already exist elsewhere).

This avoids many requests to the stack for each imported files and saves a lot of time

If the destination folder was removed, throw a specific error to let the
flagship app handle the situation (recreate the destination folder,
update the trigger with folder_to_save, etc)

I finally did not need any folder map, since cozy-client has it's own with [ensureDirectoryExists](https://github.com/cozy/cozy-client/blob/81e6523fab6fc927e6526d880910608124168059/packages/cozy-stack-client/src/FileCollection.js#L865-L871)
