### PR TITLE
(clisk)feat: Explicit type when updating file

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -312,6 +312,7 @@ async function createFile(client, entry, options, method, file) {
       _id: file._id,
       _rev: file._rev,
       _type: 'io.cozy.files',
+      type: 'file',
       data: toCreate,
       ...createFileOptions
     })


### PR DESCRIPTION
The attribut type is silently added by the stack client.

We decided to avoid magical stuff, and explicit it in each call.

So this PR.
