### PR TITLE
fix: No more undefined in not a function when saveFiles with empty array

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -63,11 +63,24 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @returns {Promise<Array<saveFilesEntry>>} - resulting entries
  */
 const saveFiles = async (client, entries, folderPath, options) => {
+  const log = (level, label, msg) => {
+    if (options.log) {
+      options.log({
+        level,
+        namespace: 'saveFiles',
+        label,
+        msg
+      })
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`${level}: saveFiles: ${label}: ${msg}`)
+    }
+  }
   if (!entries) {
     throw new Error('Savefiles : No list of files given')
   }
   if (entries.length === 0) {
-    options.log('warning', 'saveFiles', 'No file to download')
+    log('warning', 'saveFiles', 'No file to download')
   }
   if (!options.manifest) {
     throw new Error('Savefiles : no manifest')
@@ -92,19 +105,7 @@ const saveFiles = async (client, entries, folderPath, options) => {
 
   const saveOptions = {
     folderPath,
-    log: (level, label, msg) => {
-      if (options.log) {
-        options.log({
-          level,
-          namespace: 'saveFiles',
-          label,
-          msg
-        })
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(`${level}: saveFiles: ${label}: ${msg}`)
-      }
-    },
+    log,
     retry: options.retry,
     subPath: options.subPath,
     fileIdAttributes: options.fileIdAttributes,

--- a/packages/cozy-clisk/src/launcher/saveFiles.spec.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.spec.js
@@ -394,4 +394,40 @@ describe('saveFiles', function () {
       })
     ).rejects.toThrow('MAIN_FOLDER_REMOVED')
   })
+
+  it('should work even with an empty array of entries and no logger in options', async () => {
+    const client = {
+      save: jest.fn().mockImplementation(doc => ({
+        data: doc
+      })),
+      collection: () => ({
+        statByPath: jest
+          .fn()
+          .mockImplementation(async path => ({ data: { _id: path } }))
+      })
+    }
+
+    const downloadAndFormatFile = jest.fn().mockResolvedValue({
+      dataUri: 'downloaded file content'
+    })
+
+    let caught = false
+    try {
+      await saveFiles(client, [], '/test/folder/path', {
+        manifest: {
+          slug: 'testslug'
+        },
+        sourceAccount: 'testsourceaccount',
+        sourceAccountIdentifier: 'testsourceaccountidentifier',
+        fileIdAttributes: ['filename'],
+        existingFilesIndex: new Map(),
+        downloadAndFormatFile
+      })
+    } catch (err) {
+      caught = true
+      // eslint-disable-next-line no-console
+      console.error('err', err)
+    }
+    expect(caught).toBe(false)
+  })
 })


### PR DESCRIPTION
When saveFiles was called with an empty array and no log function was
passed to saveFiles, this would generate the following error :

```
undefined is not a function
```

Now, the logger is initialized sooner.
Flagship app will also need an update to pass the log option.
