### PR TITLE
feat: Set a default timeout to waitForElementInWorker

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -394,8 +394,8 @@ export default class ContentScript {
   /**
    * Click on a given element and wait for another given element to be displayed on screen
    *
-   * @param {string} elementToClick
-   * @param {string} elementToWait
+   * @param {string} elementToClick - css selector of the dom element to click in worker
+   * @param {string} elementToWait - css selector of the dom element to wait in worker
    * @returns {Promise<void>}
    */
   async clickAndWait(elementToClick, elementToWait) {

--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -15,6 +15,7 @@ const m = 60 * s
 
 const DEFAULT_LOGIN_TIMEOUT = 5 * m
 const DEFAULT_WAIT_FOR_ELEMENT_TIMEOUT = 30 * s
+const DEFAULT_WAIT_FOR_ELEMENT_ACCROSS_PAGES_TIMEOUT = 60 * s
 
 export const PILOT_TYPE = 'pilot'
 export const WORKER_TYPE = 'worker'
@@ -291,7 +292,8 @@ export default class ContentScript {
     this.onlyIn(PILOT_TYPE, 'waitForElementInWorker')
     await this.runInWorkerUntilTrue({
       method: 'waitForElementNoReload',
-      timeout: options?.timeout,
+      timeout:
+        options?.timeout ?? DEFAULT_WAIT_FOR_ELEMENT_ACCROSS_PAGES_TIMEOUT,
       args: [selector, { includesText: options.includesText }]
     })
   }


### PR DESCRIPTION
This way, runInWorkerUntilTrue will timeout even if the current page reloads indefinitely because default timeout value for
runInWorkerUntilTrue is Infinity.

- docs: Fix lint warning on jsdocs
