### PR TITLE
feat: Add forceReplaceFile entry attribute to saveFiles

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -15,7 +15,7 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @property {string} [subPath] - subPath of the destination folder path where to put the downloaded file
  * @property {import('cozy-client/types/types').IOCozyFile} [existingFile] - already existing file corresponding to the entry
  * @property {boolean} [shouldReplace] - Internal result of the shouldReplaceFile function on the entry
- * @property {Function} [shouldReplaceFile] - Function which will define if the file should be replaced or not
+ * @property {boolean} [forceReplaceFile] - should the konnector force the replace of the current file
  */
 
 /**
@@ -591,11 +591,12 @@ const defaultShouldReplaceFile = (file, entry, options) => {
   return result
 }
 /**
+ * Determine if we should replace the current file if any
  *
  * @param {import('cozy-client/types/types').IOCozyFile} file - io.cozy.files document
  * @param {saveFilesEntry} entry - saveFiles entry
  * @param {saveFileOptions} options - saveFiles options
- * @returns boolean
+ * @returns {boolean} - should we replace the current file
  */
 const shouldReplaceFile = function (file, entry, options) {
   const isValid = !options.validateFile || options.validateFile(file)
@@ -607,12 +608,11 @@ const shouldReplaceFile = function (file, entry, options) {
     )
     throw new Error('BAD_DOWNLOADED_FILE')
   }
-  const shouldReplaceFileFn =
-    entry.shouldReplaceFile ||
-    options.shouldReplaceFile ||
-    defaultShouldReplaceFile
 
-  return shouldReplaceFileFn(file, entry, options)
+  const result =
+    entry.forceReplaceFile ?? defaultShouldReplaceFile(file, entry, options)
+
+  return result
 }
 
 /**
@@ -757,6 +757,7 @@ function sanitizeEntry(entry) {
   delete entry.shouldReplaceFile
   delete entry.existingFile
   delete entry.shouldReplace
+  delete entry.forceReplaceFile
   delete entry.fileAttributes
   return entry
 }

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -252,7 +252,11 @@ const saveFile = async function (client, entry, options) {
     }
   }
 
-  if (entry.fileurl && !entry.existingFile && options.downloadAndFormatFile) {
+  if (
+    entry.fileurl &&
+    (!entry.existingFile || entry.shouldReplace) &&
+    options.downloadAndFormatFile
+  ) {
     const downloadedEntry = await options.downloadAndFormatFile(entry)
     resultEntry.dataUri = downloadedEntry.dataUri
     delete resultEntry.fileurl

--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -27,8 +27,6 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @property {Function} log - Logging function coming from the Launcher
  * @property {string} [subPath] - subPath of the destination folder path where to put the downloaded file
  * @property {string} [contentType] - will force the contentType of the file if any
- * @property {Function} [shouldReplaceFile] - Function which will define if the file should be replaced or not
- * @property {Function} [validateFile] - this function will check if the downloaded file is correct (by default, error if file size is 0)
  * @property {Function} [downloadAndFormatFile] - this callback will download the file and format to be useable by cozy-client
  * @property {string} [qualificationLabel] - qualification label defined in cozy-client which will be used on all given files
  * @property {number} [retry] - number of retries if the download of a file failes. No retry by default
@@ -42,8 +40,6 @@ import { dataUriToArrayBuffer } from '../libs/utils'
  * @property {Function} log - Logging function coming from the Launcher
  * @property {string} [subPath] - subPath of the destination folder path where to put the downloaded file
  * @property {string} [contentType] - will force the contentType of the file if any
- * @property {Function} [shouldReplaceFile] - Function which will define if the file should be replaced or not
- * @property {Function} [validateFile] - this function will check if the downloaded file is correct (by default, error if file size is 0)
  * @property {Function} [downloadAndFormatFile] - this callback will download the file and format to be useable by cozy-client
  * @property {string} [qualificationLabel] - qualification label defined in cozy-client which will be used on all given files
  * @property {number} [retry] - number of retries if the download of a file failes. No retry by default
@@ -112,8 +108,7 @@ const saveFiles = async (client, entries, folderPath, options) => {
     fileIdAttributes: options.fileIdAttributes,
     manifest: options.manifest,
     contentType: options.contentType,
-    shouldReplaceFile: options.shouldReplaceFile,
-    validateFile: options.validateFile || defaultValidateFile,
+    validateFile: defaultValidateFile,
     downloadAndFormatFile: options.downloadAndFormatFile,
     qualificationLabel: options.qualificationLabel,
     sourceAccountOptions: {
@@ -527,11 +522,12 @@ async function createFile({ client, entry, options, method, file, dirId }) {
   return fileDocument
 }
 /**
+ * Default function to determine if we should replace a file
  *
- * @param {import('cozy-client/types/types').IOCozyFile} file
- * @param {saveFilesEntry} entry
- * @param {saveFileOptions} options
- * @returns boolean
+ * @param {import('cozy-client/types/types').IOCozyFile} file - the existing file if any
+ * @param {saveFilesEntry} entry - the current entry
+ * @param {saveFileOptions} options - saveFile options
+ * @returns {boolean} - should we replace the current file
  */
 const defaultShouldReplaceFile = (file, entry, options) => {
   if (!file) return false
@@ -603,7 +599,7 @@ const defaultShouldReplaceFile = (file, entry, options) => {
  * @returns {boolean} - should we replace the current file
  */
 const shouldReplaceFile = function (file, entry, options) {
-  const isValid = !options.validateFile || options.validateFile(file)
+  const isValid = options.validateFile(file)
   if (!isValid) {
     options.log(
       'warning',


### PR DESCRIPTION
This option will force the replacement of the given file.

It takes the place of the shouldReplaceFile option function which we don't want to serialize and run in flagship app environment.

Another PR will bring shouldReplaceFile option at content script level.

- fix: Use the shouldReplace attribute to download the file from the worker
- fix: Remove validateFile and shouldReplaceFile options from saveFiles
