### PR TITLE
feat: Handle shouldReplaceFile at the ContentScript level

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.spec.js
@@ -2,6 +2,128 @@ import ContentScript, { PILOT_TYPE } from './ContentScript'
 import { Q } from 'cozy-client'
 
 describe('ContentScript', () => {
+  describe('saveFiles', () => {
+    it('should call launcher saveFiles with given nominal options', async () => {
+      const contentScript = new ContentScript()
+      contentScript.setContentScriptType(PILOT_TYPE)
+      contentScript.bridge = {
+        call: jest.fn(),
+        emit: jest.fn()
+      }
+      await contentScript.saveFiles(
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1'
+          }
+        ],
+        { context: {} }
+      )
+      expect(contentScript.bridge.call).toHaveBeenCalledTimes(1)
+      expect(contentScript.bridge.call).toHaveBeenCalledWith(
+        'saveFiles',
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1'
+          }
+        ],
+        { context: {} }
+      )
+    })
+    it('should force file replace when shouldReplace file in options returns true', async () => {
+      const contentScript = new ContentScript()
+      contentScript.setContentScriptType(PILOT_TYPE)
+      contentScript.bridge = {
+        call: jest.fn(),
+        emit: jest.fn()
+      }
+      await contentScript.saveFiles(
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1'
+          },
+          {
+            filename: 'testfile2.pdf',
+            fileurl: 'https://filedownload.com/file2'
+          }
+        ],
+        {
+          context: {},
+          shouldReplaceFile: (file, entry) => {
+            const result = entry.filename === 'testfile2.pdf'
+            return result
+          },
+          fileIdAttributes: ['filename']
+        }
+      )
+      expect(contentScript.bridge.call).toHaveBeenCalledTimes(1)
+      expect(contentScript.bridge.call).toHaveBeenCalledWith(
+        'saveFiles',
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1',
+            forceReplaceFile: false
+          },
+          {
+            filename: 'testfile2.pdf',
+            fileurl: 'https://filedownload.com/file2',
+            forceReplaceFile: true
+          }
+        ],
+        {
+          context: {},
+          fileIdAttributes: ['filename']
+        }
+      )
+    })
+    it('should force file replace when shouldReplace file in entry returns true', async () => {
+      const contentScript = new ContentScript()
+      contentScript.setContentScriptType(PILOT_TYPE)
+      contentScript.bridge = {
+        call: jest.fn(),
+        emit: jest.fn()
+      }
+      await contentScript.saveFiles(
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1',
+            shouldReplaceFile: () => true
+          },
+          {
+            filename: 'testfile2.pdf',
+            fileurl: 'https://filedownload.com/file2'
+          }
+        ],
+        {
+          context: {},
+          fileIdAttributes: ['filename']
+        }
+      )
+      expect(contentScript.bridge.call).toHaveBeenCalledTimes(1)
+      expect(contentScript.bridge.call).toHaveBeenCalledWith(
+        'saveFiles',
+        [
+          {
+            filename: 'testfile.pdf',
+            fileurl: 'https://filedownload.com/file1',
+            forceReplaceFile: true
+          },
+          {
+            filename: 'testfile2.pdf',
+            fileurl: 'https://filedownload.com/file2'
+          }
+        ],
+        {
+          context: {},
+          fileIdAttributes: ['filename']
+        }
+      )
+    })
+  })
   describe('queryAll', () => {
     it('should convert the given query definition to a serializable object', async () => {
       const contentScript = new ContentScript()

--- a/packages/cozy-clisk/src/libs/utils.js
+++ b/packages/cozy-clisk/src/libs/utils.js
@@ -26,3 +26,16 @@ export const dataUriToArrayBuffer = dataURI => {
   }
   return { contentType, arrayBuffer }
 }
+
+/**
+ * Calculate the file key from an entry given to saveFiles
+ *
+ * @param {import('../launcher/saveFiles').saveFilesEntry} entry - a savefiles entry
+ * @param {Array<string>} fileIdAttributes - list of entry attributes which will be used to identify the entry in a unique way
+ * @returns {string} - The resulting file key
+ */
+export const calculateFileKey = (entry, fileIdAttributes) =>
+  fileIdAttributes
+    .sort()
+    .map(key => entry?.[key])
+    .join('####')


### PR DESCRIPTION
It is now possible to give shouldReplaceFile function to saveFiles at
ContentScript level like this :

```javascript
await this.saveFiles([{
 filename: 'testfile.pdf',
 fileurl: '...',
 shouldReplaceFile: (existingFile, entry) => {
  // return true when the file should be replaced
 }
}])
```

or

```javascript
await this.saveFiles([{
 filename: 'testfile.pdf',
 fileurl: '...'
}], {
   shouldReplaceFile: (existingFile, entry) => {
    // return true when the file should be replaced
   }
})
```
