### PR TITLE
fix: saveIdentity tries to take care of malformed data

### DIFF
--- a/packages/cozy-konnector-libs/src/index.js
+++ b/packages/cozy-konnector-libs/src/index.js
@@ -11,7 +11,7 @@ module.exports = {
   log,
   saveFiles: require('./libs/saveFiles'),
   saveBills: require('./libs/saveBills'),
-  saveIdentity: require('./libs/saveIdentity'),
+  saveIdentity: require('./libs/saveIdentity').saveIdentity,
   linkBankOperations: require('./libs/linkBankOperations'),
   addData: require('./libs/addData'),
   hydrateAndFilter,

--- a/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
+++ b/packages/cozy-konnector-libs/src/libs/BaseKonnector.js
@@ -8,7 +8,7 @@ const signin = require('./signin')
 const get = require('lodash/get')
 const omit = require('lodash/omit')
 const updateOrCreate = require('./updateOrCreate')
-const saveIdentity = require('./saveIdentity')
+const saveIdentity = require('./saveIdentity').saveIdentity
 const fs = require('fs').promises
 const path = require('path')
 const {

--- a/packages/cozy-konnector-libs/src/libs/saveIdentity.js
+++ b/packages/cozy-konnector-libs/src/libs/saveIdentity.js
@@ -71,14 +71,7 @@ const saveIdentity = async (
     : { contact: contactOrIdentity }
   identity.identifier = accountIdentifier
 
-  // Format contact if needed
-  if (identity.contact.phone) {
-    identity.contact.phone = formatPhone(identity.contact.phone)
-  }
-  if (identity.contact.address) {
-    identity.contact.address = formatAddress(identity.contact.address)
-  }
-
+  identity.contact = formatIdentityContact(identity.contact)
   if (options.merge == false) {
     // Using cozy client in a none merging strategy here.
     const newClient = cozyClient.new
@@ -133,6 +126,8 @@ function formatAddress(address) {
         .replace(/<[^>]*>/g, '') // Remove all html Tag
         .replace(/\r\n|[\n\r]/g, ' ') // Remove all kind of return character
       address[address.indexOf(element)] = element
+    } else {
+      log('warn', 'There is no formattedAddress in address object')
     }
   }
   return address
@@ -145,9 +140,57 @@ function formatPhone(phone) {
     if (element.number) {
       element.number = element.number.replace(/[^\d.+]/g, '')
       phone[phone.indexOf(element)] = element
+    } else {
+      log('warn', 'There is no number in phone object')
     }
   }
   return phone
 }
 
-module.exports = saveIdentity
+function formatIdentityContact(contactToFormat) {
+  const contact = { ...contactToFormat }
+  if (contact.phone) {
+    if (!Array.isArray(contact.phone)) {
+      log(
+        'warn',
+        'formatIdentityContact Phone is not an array, you should fix it'
+      )
+      contact.phone = [
+        {
+          number: contact.phone
+        }
+      ]
+    }
+    contact.phone = formatPhone(contact.phone)
+  }
+
+  if (contact.address) {
+    if (!Array.isArray(contact.address)) {
+      log(
+        'warn',
+        'formatIdentityContact Address is not an array, you should fix it'
+      )
+      contact.address = [
+        {
+          formattedAddress: contact.address
+        }
+      ]
+    }
+    contact.address = formatAddress(contact.address)
+  }
+  if (contact.email) {
+    if (!Array.isArray(contact.email)) {
+      log(
+        'warn',
+        'formatIdentityContact Email is not an array, you should fix it'
+      )
+      contact.email = [
+        {
+          address: contact.email
+        }
+      ]
+    }
+  }
+  return contact
+}
+module.exports = { saveIdentity, formatIdentityContact }

--- a/packages/cozy-konnector-libs/src/libs/saveIdentity.spec.js
+++ b/packages/cozy-konnector-libs/src/libs/saveIdentity.spec.js
@@ -7,7 +7,8 @@ jest.mock('./cozyclient', () => ({
 }))
 
 const updateOrCreate = require('./updateOrCreate')
-const saveIdentity = require('./saveIdentity')
+const saveIdentity = require('./saveIdentity').saveIdentity
+const formatIdentityContact = require('./saveIdentity').formatIdentityContact
 const cozyClient = require('./cozyclient')
 
 describe('saveIdentity', () => {
@@ -94,5 +95,40 @@ describe('saveIdentity', () => {
       contact: { name: 'test2' },
       identifier: 'myidentifier'
     })
+  })
+})
+
+describe('formatIdentityContact', () => {
+  fit('should format (create the array) phone, address & mail if only strings', () => {
+    const contact = {
+      phone: '0601020304',
+      address: '1 rue de la paix',
+      email: 'foo@cozycloud.cc'
+    }
+    const formattedContact = formatIdentityContact(contact)
+
+    const expectedContact = {
+      phone: [{ number: contact.phone }],
+      address: [{ formattedAddress: contact.address }],
+      email: [{ address: contact.email }]
+    }
+
+    expect(formattedContact).toEqual(expectedContact)
+  })
+  fit('should format (create the array) phone, address & mail if string or array', () => {
+    const contact = {
+      phone: [{ number: '0601020304' }],
+      address: '1 rue de la paix',
+      email: 'foo@cozycloud.cc'
+    }
+    const formattedContact = formatIdentityContact(contact)
+
+    const expectedContact = {
+      phone: contact.phone,
+      address: [{ formattedAddress: contact.address }],
+      email: [{ address: contact.email }]
+    }
+
+    expect(formattedContact).toEqual(expectedContact)
   })
 })


### PR DESCRIPTION
If strings are passed when we want array, we try to fix them. We also add warns in order to fix the root cause.