### PR TITLE
[SCR-61] fix: ContentScript.waitForDomReady on android

### DIFF
--- a/packages/cozy-clisk/src/contentscript/ContentScript.js
+++ b/packages/cozy-clisk/src/contentscript/ContentScript.js
@@ -215,8 +215,9 @@ export default class ContentScript {
     const domReadyPromise = new Promise(resolve => {
       // first check if the DOMContentLoad has already been called
       if (
-        document.readyState === 'complete' ||
-        document.readyState === 'loaded'
+        document?.readyState === 'complete' ||
+        document?.readyState === 'loaded' ||
+        document?.readyState === 'interactive'
       ) {
         resolve()
       } else {


### PR DESCRIPTION
This method did not always work on android and the promise was resolved
only after the timeout of 10s.

This was caused by the document.readyState which could also be
'interactive'. In this case, DOMContentLoad is not supposed to be
already triggered but we cauld miss it while setting the
DOMContentLoaded listener

Since what we are really waiting for in an interactive page, this fix is
correct.
