### PR TITLE
chore: use cozy-client as peerDep in cozy-clisk (VO-265)

### DIFF
--- a/packages/cozy-clisk/package.json
+++ b/packages/cozy-clisk/package.json
@@ -36,11 +36,13 @@
   "dependencies": {
     "@cozy/minilog": "^1.0.0",
     "bluebird-retry": "^0.11.0",
-    "cozy-client": "^41.2.0",
     "ky": "^0.25.1",
     "lodash": "^4.17.21",
     "p-timeout": "^6.0.0",
     "p-wait-for": "^5.0.2",
     "post-me": "^0.4.5"
+  },
+  "peerDependencies": {
+    "cozy-client": ">=41.2.0"
   }
 }


### PR DESCRIPTION
Not doing so can introduce breaking behaviour in the consuming app if it's using a different version of cozy-client