### PR TITLE
[SCR-402] fix: All disk quota error message to konnector status

### DIFF
--- a/packages/cozy-clisk/src/launcher/saveFiles.js
+++ b/packages/cozy-clisk/src/launcher/saveFiles.js
@@ -398,7 +398,10 @@ const saveFile = async function (client, entry, options) {
         max_tries: options.retry,
         args: [client, resultEntry, options, method, resultEntry.existingFile]
       }).catch(err => {
-        if (err.message === 'MAIN_FOLDER_REMOVED') {
+        if (
+          err.message === 'MAIN_FOLDER_REMOVED' ||
+          getErrorStatus(err) === 413
+        ) {
           throw err
         }
         if (err.message === 'BAD_DOWNLOADED_FILE') {

--- a/packages/cozy-konnector-libs/src/libs/saveFiles.js
+++ b/packages/cozy-konnector-libs/src/libs/saveFiles.js
@@ -292,6 +292,8 @@ const saveEntry = async function (entry, options) {
             'warn',
             `Could not download file after ${options.retry} tries removing the file`
           )
+        } else if (getErrorStatus(err) === 413) {
+          throw err
         } else {
           log('warn', 'unknown file download error: ' + err.message)
         }


### PR DESCRIPTION
The 413 disk quota error was swallowed in saveFiles and did not make it to the full konnector status.
Now the correct disk quota error message will be displayed to the user.