### PR TITLE
fix script cozy-run-shell

### DIFF
--- a/packages/cozy-konnector-libs/docs/cli.md
+++ b/packages/cozy-konnector-libs/docs/cli.md
@@ -119,7 +119,7 @@ tools available and some enhancements.
 
 ```javascript
   scripts: {
-    dev: "cozy-run-shell"
+    shell: "cozy-run-shell"
   }
 ```
 


### PR DESCRIPTION
The [documentation](https://docs.cozy.io/en/cozy-konnector-libs/cli/#cozy-run-shell) requires adding a "dev" script but right after `yarn shell` is run.

This PR fixes this copy/paste. 